### PR TITLE
Hide mission details modal on initial load

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -59,7 +59,8 @@
   position: fixed; top: 10%; left: 50%; transform: translateX(-50%);
   background: white; padding: 1em; border: 2px solid #444;
   box-shadow: 0 0 10px rgba(0,0,0,0.3); z-index: 9999;
-  width: 420px; max-height: 80vh; overflow-y: auto; border-radius: 8px;">
+  width: 420px; max-height: 80vh; overflow-y: auto; border-radius: 8px;
+  display: none;">
         <div style="text-align:right;">
                 <button onclick="document.getElementById('missionDetails').style.display = 'none';">Close</button>
         </div>


### PR DESCRIPTION
## Summary
- Hide mission details modal by default to prevent popup on page load

## Testing
- `npm test` (fails: Error: no test specified)


------
https://chatgpt.com/codex/tasks/task_e_68ac21c62524832892e7603a1eead845