### PR TITLE
Allow removing equipment from units

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1035,7 +1035,7 @@ async function showUnitDetails(unitId) {
     : [];
 
   const equipmentHtml = eqNames.length
-    ? `<ul>${eqNames.map(n => `<li>${n}</li>`).join('')}</ul>`
+    ? `<ul>${eqNames.map(n => `<li>${n} <button class="remove-equip-btn" data-name="${n}">Remove</button></li>`).join('')}</ul>`
     : '<em>No equipment</em>';
   const availableEq = Array.isArray(station?.equipment) ? station.equipment : [];
   const assignHtml = availableEq.length
@@ -1075,6 +1075,24 @@ async function showUnitDetails(unitId) {
       });
       modal.style.display = "none";
       showStationDetails({ id: sid });
+    });
+  });
+  content.querySelectorAll('.remove-equip-btn').forEach(btn => {
+    btn.addEventListener('click', async () => {
+      const name = btn.dataset.name;
+      const res = await fetch(`/api/units/${unitId}/equipment`, {
+        method: 'DELETE',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ station_id: unit.station_id, name })
+      });
+      const data = await res.json();
+      if (!res.ok || !data.success) {
+        alert(`Failed: ${data.error || res.statusText}`);
+        return;
+      }
+      _unitById.set(unitId, { ...unit, equipment: data.equipment });
+      modal.style.display = 'none';
+      refreshStationPanelNoCache(unit.station_id);
     });
   });
   const assignBtn = content.querySelector('#assign-equip-btn');

--- a/server.js
+++ b/server.js
@@ -724,6 +724,42 @@ app.patch('/api/units/:id/equipment', (req, res) => {
   });
 });
 
+// Remove equipment from a unit back to station storage
+app.delete('/api/units/:id/equipment', (req, res) => {
+  const unitId = Number(req.params.id);
+  const stationId = Number(req.body?.station_id);
+  const name = String(req.body?.name || '').trim();
+  if (!unitId || !stationId || !name) {
+    return res.status(400).json({ error: 'unit_id, station_id and name are required' });
+  }
+
+  db.get(`SELECT equipment, equipment_slots FROM stations WHERE id=?`, [stationId], (err, st) => {
+    if (err) return res.status(500).json({ error: err.message });
+    if (!st) return res.status(404).json({ error: 'Station not found' });
+    let stList; try { stList = JSON.parse(st.equipment || '[]'); } catch { stList = []; }
+    const slots = Number(st.equipment_slots || 0);
+
+    db.get(`SELECT equipment FROM units WHERE id=?`, [unitId], (err2, u) => {
+      if (err2) return res.status(500).json({ error: err2.message });
+      if (!u) return res.status(404).json({ error: 'Unit not found' });
+      let uList; try { uList = JSON.parse(u.equipment || '[]'); } catch { uList = []; }
+      const idx = uList.indexOf(name);
+      if (idx === -1) return res.status(404).json({ error: 'Equipment not found on unit' });
+      if (slots && stList.length >= slots) return res.status(409).json({ error: 'No free equipment slots' });
+
+      uList.splice(idx, 1);
+      stList.push(name);
+      db.serialize(() => {
+        db.run(`UPDATE units SET equipment=? WHERE id=?`, [JSON.stringify(uList), unitId]);
+        db.run(`UPDATE stations SET equipment=? WHERE id=?`, [JSON.stringify(stList), stationId], function (e3) {
+          if (e3) return res.status(500).json({ error: e3.message });
+          res.json({ success: true, unit_id: unitId, equipment: uList, station_equipment: stList });
+        });
+      });
+    });
+  });
+});
+
 // Ensure station has a free bay
 async function ensureStationHasFreeBay(stationId) {
   return new Promise((resolve, reject) => {


### PR DESCRIPTION
## Summary
- allow station equipment to be returned from units
- add remove buttons for unit equipment in unit detail popup

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68ac2675482083289d64a559b10180f2