### PR TITLE
Include training costs in personnel recruitment

### DIFF
--- a/trainings.js
+++ b/trainings.js
@@ -27,3 +27,7 @@ const trainingsByClass = {
     { name: "incident command", cost: 1000 }
   ]
 };
+
+if (typeof module !== 'undefined' && typeof module.exports !== 'undefined') {
+  module.exports = trainingsByClass;
+}


### PR DESCRIPTION
## Summary
- Export `trainings.js` so the server can access training definitions
- Personnel recruitment endpoint charges $100 base plus the sum of required training costs

## Testing
- `node -e "const trainings=require('./trainings'); console.log(trainings.fire[0]);"`
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68ac269af9188328a25b0c05e02c9e37