### PR TITLE
Fix mission unit details endpoint

### DIFF
--- a/server.js
+++ b/server.js
@@ -454,15 +454,37 @@ app.delete('/api/missions', (req, res) => {
 });
 
 app.get('/api/missions/:id/units', (req, res) => {
-  db.all(`
-    SELECT u.*
-    FROM mission_units mu
-    JOIN units u ON u.id = mu.unit_id
-    WHERE mu.mission_id = ?
-  `, [req.params.id], (err, rows) => {
-    if (err) return res.status(500).json({ error: err.message });
-    res.json(rows || []);
-  });
+  db.all(
+    `SELECT
+       u.id, u.station_id, u.class, u.type, u.name, u.status, u.equipment,
+       COALESCE(json_group_array(
+         json_object('id', p.id, 'name', p.name, 'training', p.training)
+       ), '[]') AS personnel
+     FROM mission_units mu
+     JOIN units u ON u.id = mu.unit_id
+     LEFT JOIN personnel p ON p.unit_id = u.id
+     WHERE mu.mission_id = ?
+     GROUP BY u.id`,
+    [req.params.id],
+    (err, rows) => {
+      if (err) return res.status(500).json({ error: err.message });
+      const parsed = rows.map(r => ({
+        ...r,
+        equipment: (()=>{ try { return JSON.parse(r.equipment||'[]'); } catch { return []; } })(),
+        personnel: (()=>{
+          try {
+            return JSON.parse(r.personnel||'[]').map(p => ({
+              ...p,
+              training: (()=>{ try { return JSON.parse(p.training||'[]'); } catch { return []; } })()
+            }));
+          } catch {
+            return [];
+          }
+        })()
+      }));
+      res.json(parsed);
+    }
+  );
 });
 // Get personnel for a station (only unassigned)
 app.get('/api/stations/:id/personnel', (req, res) => {


### PR DESCRIPTION
## Summary
- Include equipment and detailed personnel (with training) in /api/missions/:id/units
- Parse JSON fields so mission popup correctly assesses resources

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68ace38273448328adbad0c1efad2b98