### PR TITLE
Add unit cancel option to free stuck units

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -728,8 +728,9 @@ async function showStationDetails(station) {
     <ul id="unit-list">
       ${units.map(u=>`
         <li>
-          <strong style="cursor:pointer; color:blue;" onclick="showUnitDetails(${u.id})">${u.name}</strong> (${u.type})
+          <strong style="cursor:pointer; color:blue;" onclick="showUnitDetails(${u.id})">${u.name}</strong> (${u.type}) - ${u.status}
           <button onclick="openAssignModal(${u.id}, ${station.id})">Assign</button>
+          ${u.status !== 'available' ? `<button onclick="cancelUnit(${u.id}, ${station.id})">Cancel</button>` : ''}
         </li>`).join('')}
     </ul>`;
         async function refreshBayInfo(stationId) {
@@ -1077,6 +1078,17 @@ async function openAssignModal(unitId, stationId) {
   };
 
   modal.style.display = "block";
+}
+
+async function cancelUnit(unitId, stationId) {
+  if (!confirm('Cancel this unit?')) return;
+  const res = await fetch(`/api/units/${unitId}/cancel`, { method: 'POST' });
+  if (!res.ok) {
+    const msg = await res.text();
+    alert(`Failed: ${msg}`);
+    return;
+  }
+  refreshStationPanelNoCache(stationId);
 }
 
 async function showUnitDetails(unitId) {

--- a/server.js
+++ b/server.js
@@ -817,6 +817,20 @@ app.patch('/api/units/:id/status', (req, res) => {
   });
 });
 
+// Cancel unit: free it from any mission and set available
+app.post('/api/units/:id/cancel', (req, res) => {
+  const id = parseInt(req.params.id, 10);
+  if (!id) return res.status(400).json({ error: 'invalid id' });
+  db.serialize(() => {
+    db.run('DELETE FROM mission_units WHERE unit_id=?', [id]);
+    db.run('DELETE FROM unit_travel WHERE unit_id=?', [id]);
+    db.run('UPDATE units SET status=? WHERE id=?', ['available', id], function (err) {
+      if (err) return res.status(500).json({ error: err.message });
+      res.json({ ok: true });
+    });
+  });
+});
+
 /* =========================
    Personnel
    ========================= */


### PR DESCRIPTION
## Summary
- show each unit's status in station view and provide a cancel button to free busy units
- add `/api/units/:id/cancel` endpoint to remove a unit from any mission and mark it available

## Testing
- ⚠️ `npm test` (fails: Error: no test specified)


------
https://chatgpt.com/codex/tasks/task_e_68acee6fa92483289a1acffa78a51cf9