### PR TITLE
Add run card dispatch system

### DIFF
--- a/public/admin.html
+++ b/public/admin.html
@@ -15,6 +15,7 @@
   
   <button id="new-mission-btn">Create New Mission</button>
   <div id="mission-form-container" style="display: none;"></div>
+  <div id="runcard-form-container" style="display: none;"></div>
 
   <h2>Existing Missions</h2>
   <table id="mission-table" border="1">
@@ -25,8 +26,13 @@
         <th>Trigger Filter</th>
         <th>Timing</th>
         <th>Required Units</th>
-		<th>Rewards</th>
-			<th>Edit</th>
+        <th>Required Training</th>
+        <th>Equipment</th>
+        <th>Modifiers</th>
+        <th>Patients</th>
+        <th>Prisoners</th>
+        <th>Rewards</th>
+        <th>Actions</th>
       </tr>
     </thead>
     <tbody></tbody>

--- a/public/admin.js
+++ b/public/admin.js
@@ -43,8 +43,13 @@ function appendMissionRow(mission) {
     <td>${mission.trigger_filter}</td>
     <td>${mission.timing}</td>
     <td>${(mission.required_units || []).map(u => `${u.quantity ?? u.count}×${u.type}`).join(", ")}</td>
+    <td>${(mission.required_training || []).map(t => `${t.qty ?? t.quantity ?? t.count ?? 1}×${t.training ?? t.name ?? t}`).join(", ")}</td>
+    <td>${(mission.equipment_required || []).map(e => `${e.qty ?? e.quantity ?? e.count ?? 1}×${e.name ?? e}`).join(", ")}</td>
+    <td>${(mission.modifiers || []).map(m => `${m.type}${m.timeReduction ? ` (${m.timeReduction}%)` : ''}${m.maxCount ? ` x${m.maxCount}` : ''}`).join(", ")}</td>
+    <td>${(mission.patients || []).map(p => p.count ?? `${p.min ?? 0}-${p.max ?? 0}`).join(", ")}</td>
+    <td>${(mission.prisoners || []).map(p => p.count ?? `${p.min ?? 0}-${p.max ?? 0}`).join(", ")}</td>
     <td>${Number.isFinite(mission.rewards) ? mission.rewards : 0}</td>
-    <td><button onclick="editMission(${mission.id})">Edit</button></td>
+    <td><button onclick="editMission(${mission.id})">Edit</button> <button onclick='editRunCard(${JSON.stringify(mission.name)})'>Run Card</button></td>
   `;
   tbody.appendChild(row);
 }
@@ -389,4 +394,127 @@ function collectRows(containerSel) {
     });
     return obj;
   });
+}
+
+// ----- Run card management -----
+async function editRunCard(name) {
+  const container = document.getElementById('runcard-form-container');
+  container.style.display = 'block';
+  let existing = null;
+  try {
+    const res = await fetch(`/api/run-cards/${encodeURIComponent(name)}`);
+    if (res.ok) existing = await res.json();
+  } catch {}
+
+  container.innerHTML = `
+    <h3>Run Card for ${name}</h3>
+    <div><strong>Units</strong></div>
+    <div id="rc-unit-container"></div>
+    <button type="button" onclick="addRCUnitRow()">Add Unit</button><br>
+    <div><strong>Training</strong></div>
+    <div id="rc-training-container"></div>
+    <button type="button" onclick="addRCTrainingRow()">Add Training</button><br>
+    <div><strong>Equipment</strong></div>
+    <div id="rc-equipment-container"></div>
+    <button type="button" onclick="addRCEquipmentRow()">Add Equipment</button><br>
+    <button onclick="saveRunCard(${JSON.stringify(name)})">Save</button>
+    <button onclick="document.getElementById('runcard-form-container').style.display='none'">Close</button>
+  `;
+
+  (existing?.units || []).forEach(u => addRCUnitRow(u.type, u.quantity ?? u.count ?? 1));
+  (existing?.training || []).forEach(t => addRCTrainingRow(t.training ?? t.name ?? t, t.qty ?? t.quantity ?? t.count ?? 1));
+  (existing?.equipment || []).forEach(e => addRCEquipmentRow(e.name ?? e.type ?? e, e.qty ?? e.quantity ?? e.count ?? 1));
+}
+
+function addRCUnitRow(selectedType = "", qty = 1) {
+  const container = document.getElementById('rc-unit-container');
+  const row = document.createElement('div');
+  const select = document.createElement('select');
+  unitTypes.forEach(u => {
+    const opt = document.createElement('option');
+    opt.value = u.type;
+    opt.textContent = `${u.class} - ${u.type}`;
+    if (u.type === selectedType) opt.selected = true;
+    select.appendChild(opt);
+  });
+  select.name = 'type';
+  const input = document.createElement('input');
+  input.type = 'number';
+  input.name = 'quantity';
+  input.min = 1;
+  input.value = qty;
+  const btn = document.createElement('button');
+  btn.type = 'button';
+  btn.textContent = 'Remove';
+  btn.onclick = () => container.removeChild(row);
+  row.appendChild(select);
+  row.appendChild(input);
+  row.appendChild(btn);
+  container.appendChild(row);
+}
+
+function addRCTrainingRow(selected = "", qty = 1) {
+  const container = document.getElementById('rc-training-container');
+  const row = document.createElement('div');
+  const select = document.createElement('select');
+  getTrainingDisplayList().forEach(({ name }) => {
+    const opt = document.createElement('option');
+    opt.value = name;
+    opt.textContent = name;
+    if (name === selected) opt.selected = true;
+    select.appendChild(opt);
+  });
+  select.name = 'training';
+  const input = document.createElement('input');
+  input.type = 'number';
+  input.name = 'qty';
+  input.min = 1;
+  input.value = qty;
+  const btn = document.createElement('button');
+  btn.type = 'button';
+  btn.textContent = 'Remove';
+  btn.onclick = () => container.removeChild(row);
+  row.appendChild(select);
+  row.appendChild(input);
+  row.appendChild(btn);
+  container.appendChild(row);
+}
+
+function addRCEquipmentRow(selected = "", qty = 1) {
+  const container = document.getElementById('rc-equipment-container');
+  const row = document.createElement('div');
+  const select = document.createElement('select');
+  getEquipDisplayList().forEach(({ name }) => {
+    const opt = document.createElement('option');
+    opt.value = name;
+    opt.textContent = name;
+    if (name === selected) opt.selected = true;
+    select.appendChild(opt);
+  });
+  select.name = 'name';
+  const input = document.createElement('input');
+  input.type = 'number';
+  input.name = 'qty';
+  input.min = 1;
+  input.value = qty;
+  const btn = document.createElement('button');
+  btn.type = 'button';
+  btn.textContent = 'Remove';
+  btn.onclick = () => container.removeChild(row);
+  row.appendChild(select);
+  row.appendChild(input);
+  row.appendChild(btn);
+  container.appendChild(row);
+}
+
+async function saveRunCard(name) {
+  const units = collectRows('#rc-unit-container');
+  const training = collectRows('#rc-training-container');
+  const equipment = collectRows('#rc-equipment-container');
+  await fetch(`/api/run-cards/${encodeURIComponent(name)}`, {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ units, training, equipment })
+  });
+  document.getElementById('runcard-form-container').style.display = 'none';
 }

--- a/public/index.html
+++ b/public/index.html
@@ -128,6 +128,7 @@
   <p id="cadRequired"></p>
   <button onclick="dispatchAuto()">Dispatch (Auto)</button>
   <button onclick="dispatchRecommended()">Dispatch (Recommended)</button>
+  <button onclick="dispatchRunCard()">Dispatch (Run Card)</button>
   <button onclick="manualDispatch()">Manual Dispatch</button>
   <button onclick="closeCad()">Close</button>
 </div>
@@ -642,12 +643,13 @@ function showMissionDetails(mission) {
     ${patientHtml ? '<p><strong>Patients:</strong></p>' + patientHtml : ''}
     ${prisonerHtml ? '<p><strong>Prisoners:</strong></p>' + prisonerHtml : ''}
     <div id="assignedUnitsArea" style="margin-top:8px;"></div>
-    <div style="margin-top:10px;"><button id="manualDispatchBtn">Manual Dispatch</button> <button id="autoDispatchBtn">Auto Dispatch</button></div>
+    <div style="margin-top:10px;"><button id="manualDispatchBtn">Manual Dispatch</button> <button id="autoDispatchBtn">Auto Dispatch</button> <button id="runCardDispatchBtn">Run Card Dispatch</button></div>
     <div id="manualDispatchArea" style="margin-top:8px;"></div>
     <div id="missionTimerArea" style="margin-top:8px;"></div>
   `;
   document.getElementById('manualDispatchBtn').onclick = () => openManualDispatch(mission);
   document.getElementById('autoDispatchBtn').onclick = () => autoDispatch(mission);
+  document.getElementById('runCardDispatchBtn').onclick = () => runCardDispatch(mission);
   refreshAssignedUnitsUI(mission.id).then(assigned => {
     const reqDiv = document.getElementById('reqDynamic');
     if (reqDiv) reqDiv.innerHTML = renderRequirementsDynamic(mission, assigned);
@@ -1555,6 +1557,41 @@ async function autoDispatch(mission) {
   } catch (e) {
     console.error(e);
     area.innerHTML = '<span style="color:#b00;">Auto dispatch failed.</span>';
+  }
+}
+
+async function runCardDispatch(mission) {
+  let area = document.getElementById('manualDispatchArea');
+  let tempArea = false;
+  if (!area) {
+    area = document.createElement('div');
+    area.id = 'manualDispatchArea';
+    area.style.display = 'none';
+    document.body.appendChild(area);
+    tempArea = true;
+  }
+  try {
+    const res = await fetch(`/api/run-cards/${encodeURIComponent(mission.type)}`);
+    if (!res.ok) { alert('No run card for this mission.'); return; }
+    const rc = await res.json();
+    const rcMission = {
+      ...mission,
+      required_units: rc.units || [],
+      required_training: rc.training || [],
+      equipment_required: rc.equipment || []
+    };
+    await autoDispatch(rcMission);
+  } catch (e) {
+    console.error(e);
+    alert('Run card dispatch failed.');
+  } finally {
+    if (tempArea) area.remove();
+  }
+}
+
+async function dispatchRunCard() {
+  if (window.currentMission) {
+    await runCardDispatch(window.currentMission);
   }
 }
 


### PR DESCRIPTION
## Summary
- allow admin to define mission run cards with units, training, and equipment
- expose run card API endpoints and dispatch logic
- show all mission requirements and run card button in admin panel
- add run card dispatch button on missions

## Testing
- `node --check server.js`
- `node --check public/admin.js`
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68ad0223a10c8328b6654c44e5e555b3