### PR TITLE
Fix runcard save button quoting

### DIFF
--- a/public/admin.js
+++ b/public/admin.js
@@ -417,7 +417,7 @@ async function editRunCard(name) {
     <div><strong>Equipment</strong></div>
     <div id="rc-equipment-container"></div>
     <button type="button" onclick="addRCEquipmentRow()">Add Equipment</button><br>
-    <button onclick="saveRunCard(${JSON.stringify(name)})">Save</button>
+    <button onclick='saveRunCard(${JSON.stringify(name)})'>Save</button>
     <button onclick="document.getElementById('runcard-form-container').style.display='none'">Close</button>
   `;
 


### PR DESCRIPTION
## Summary
- escape mission name when saving run cards to prevent invalid HTML in save button

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68ad0939ec548328a086f18c2f512d63