### PR TITLE
Support department-based run cards and dispatch

### DIFF
--- a/public/admin.html
+++ b/public/admin.html
@@ -24,6 +24,7 @@
         <th>Name</th>
         <th>Trigger Type</th>
         <th>Trigger Filter</th>
+        <th>Department</th>
         <th>Timing</th>
         <th>Required Units</th>
         <th>Required Training</th>

--- a/public/index.html
+++ b/public/index.html
@@ -1706,17 +1706,27 @@ async function autoDispatch(mission) {
   const area = document.getElementById('manualDispatchArea');
   area.innerHTML = 'Selecting units…';
   try {
-    const [stations, allUnitsRaw] = await Promise.all([
+    let dept = mission.department;
+    if (!dept) {
+      try {
+        const zr = await fetch(`/api/zones/lookup?lat=${mission.lat}&lon=${mission.lon}`);
+        if (zr.ok) { const z = await zr.json(); dept = z.department || dept; }
+      } catch {}
+    }
+    const [stationsRaw, allUnitsRaw] = await Promise.all([
       fetch('/api/stations').then(r=>r.json()),
       fetch('/api/units?status=available').then(r=>r.json())
     ]);
+    const stations = stationsRaw.filter(s => !dept || (s.department || s.type) === dept);
     cacheStations(stations);
     const stMap = new Map(stations.map(s=>[s.id,s]));
     const allUnits = allUnitsRaw.map(u=>{
       const st = stMap.get(u.station_id);
+      const stDept = st?.department || st?.type;
+      if (dept && stDept !== dept) return null;
       const dist = st ? haversineKm(st.lat, st.lon, mission.lat, mission.lon) : Infinity;
       return { ...u, _dist: dist };
-    });
+    }).filter(Boolean);
     const selected = [];
     const selectedIds = new Set();
 
@@ -1793,11 +1803,24 @@ async function runCardDispatch(mission) {
     tempArea = true;
   }
   try {
-    const res = await fetch(`/api/run-cards/${encodeURIComponent(mission.type)}`);
+    let dept = mission.department;
+    if (!dept) {
+      try {
+        const zr = await fetch(`/api/zones/lookup?lat=${mission.lat}&lon=${mission.lon}`);
+        if (zr.ok) { const z = await zr.json(); dept = z.department || dept; }
+      } catch {}
+    }
+    let url = `/api/run-cards/${encodeURIComponent(mission.type)}`;
+    if (dept) url += `?department=${encodeURIComponent(dept)}`;
+    let res = await fetch(url);
+    if (!res.ok && dept) {
+      res = await fetch(`/api/run-cards/${encodeURIComponent(mission.type)}`);
+    }
     if (!res.ok) { alert('No run card for this mission.'); return; }
     const rc = await res.json();
     const rcMission = {
       ...mission,
+      department: dept,
       required_units: rc.units || [],
       required_training: rc.training || [],
       equipment_required: rc.equipment || []


### PR DESCRIPTION
## Summary
- filter auto and run-card dispatch to units from the mission's department
- look up run cards per department with fallback to global defaults
- record mission, template and run card departments server-side and in admin UI

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68ad446ae6c88328ba53473837952a1b