### PR TITLE
Fix syntax error in mission API route

### DIFF
--- a/server.js
+++ b/server.js
@@ -588,14 +588,6 @@ app.post('/api/missions', (req, res) => {
     timing = 10
   } = req.body;
 
-app.post('/api/missions', (req, res) => {
-  const {
-    type, lat, lon,
-    required_units = [], required_training = [],
-    equipment_required = [], patients = [], prisoners = [], modifiers = [],
-    timing = 10
-  } = req.body;
-
   db.all('SELECT * FROM response_zones', (err, zones) => {
     if (err) return res.status(500).json({ error: err.message });
 


### PR DESCRIPTION
## Summary
- Remove duplicate `app.post('/api/missions')` handler that left an unclosed block and caused "Unexpected end of input" when starting the server

## Testing
- `npm test` *(fails: no test specified)*
- `node server.js`

------
https://chatgpt.com/codex/tasks/task_e_68ad4c155e9c8328a946d09aeae28e20