### PR TITLE
Fix await usage when building stations

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1159,7 +1159,7 @@ window.editUnit = editUnit;
 
 // Build station
 document.getElementById("buildStation").addEventListener("click", () => { buildStationMode = true; alert("Click the map to place your new station"); });
-map.on("click", (e) => {
+map.on("click", async (e) => {
   if (!buildStationMode) return;
   const name = prompt("Station Name?");
   const type = prompt("Type (fire, police, ambulance, hospital, jail)?", "fire")?.toLowerCase();


### PR DESCRIPTION
## Summary
- Mark map click handler as `async` so station creation `await` works without runtime error

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68ad4ef4e9788328a4e5b68765a3e806