### PR TITLE
Persist mission timers in database

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -500,6 +500,34 @@ async function fetchMissions() {
         Lat: ${m.lat.toFixed(4)}<br>Lon: ${m.lon.toFixed(4)}<br>`;
       missionList.appendChild(el);
     }
+
+    // Sync mission timers with server state
+    const now = Date.now();
+    const presentIds = new Set(missions.map(m => m.id));
+    for (const [id, obj] of Array.from(activeWorkTimers.entries())) {
+      if (!presentIds.has(id)) {
+        if (obj.timeoutId) clearTimeout(obj.timeoutId);
+        if (obj.intervalId) clearInterval(obj.intervalId);
+        activeWorkTimers.delete(id);
+      }
+    }
+    for (const m of missions) {
+      const end = Number(m.resolve_at);
+      if (end && end > now) {
+        const ex = activeWorkTimers.get(m.id);
+        if (!ex || ex.endTime !== end) {
+          setupTimerForMission(m, end);
+        }
+      } else {
+        const ex = activeWorkTimers.get(m.id);
+        if (ex) {
+          if (ex.timeoutId) clearTimeout(ex.timeoutId);
+          if (ex.intervalId) clearInterval(ex.intervalId);
+          activeWorkTimers.delete(m.id);
+        }
+      }
+    }
+    persistWorkTimers();
   } catch (err) {
     console.error("Failed to fetch missions:", err);
   }
@@ -2083,6 +2111,48 @@ function startMissionCountdown(missionId, endTime) {
   persistWorkTimers();
 }
 
+function setupTimerForMission(mission, endTime) {
+  const ms = Math.max(0, endTime - Date.now());
+  const tid = setTimeout(async ()=>{
+    const cur = activeWorkTimers.get(mission.id);
+    if (cur && cur.intervalId) clearInterval(cur.intervalId);
+    activeWorkTimers.delete(mission.id);
+    persistWorkTimers();
+    const assignedBefore = await (await fetch(`/api/missions/${mission.id}/units`)).json();
+    await fetch(`/api/missions/${mission.id}/resolve`, { method:'POST' });
+    if (!_stationById || _stationById.size===0) {
+      const stations = await (await fetch('/api/stations')).json();
+      cacheStations(stations);
+    }
+    for (const u of assignedBefore) {
+      const st = _stationById.get(u.station_id);
+      if (!st) continue;
+      ensureUnitMarker(u);
+      const entry = unitMarkers.get(u.id);
+      const current = entry?.marker.getLatLng() || L.latLng(mission.lat, mission.lon);
+      routeAndAnimateUnit(
+        u.id,
+        [current.lat, current.lng],
+        [st.lat, st.lon],
+        TRAVEL_SPEED[u.class] || 45,
+        () => {
+          const rp = unitRoutes.get(u.id);
+          if (rp) { try { map.removeLayer(rp); } catch {} unitRoutes.delete(u.id); }
+          fetch(`/api/unit-travel/${u.id}`, { method:'DELETE' }).catch(()=>{});
+        },
+        { phase: 'return' }
+      );
+    }
+    await refreshAssignedUnitsUI(mission.id);
+    await fetchMissions();
+    const area = document.getElementById('manualDispatchArea');
+    if (area) area.innerHTML = '<strong>Mission resolved.</strong>';
+  }, ms);
+  activeWorkTimers.set(mission.id, { timeoutId: tid, endTime });
+  startMissionCountdown(mission.id, endTime);
+  persistWorkTimers();
+}
+
 for (const [id, obj] of Array.from(activeWorkTimers.entries())) {
   startMissionCountdown(id, obj.endTime);
 }
@@ -2112,13 +2182,19 @@ async function checkMissionCompletion(mission) {
   const equipMet = reqEquip.every(r => (equipOnscene.get(r.name || r.type || r)||0) >= (r.qty ?? r.quantity ?? r.count ?? 1));
   const trainMet = reqTrain.every(r => (trainOnscene.get(r.training || r.name || r)||0) >= (r.qty ?? r.quantity ?? r.count ?? 1));
   const allMet = unitsMet && equipMet && trainMet;
-  const existing = activeWorkTimers.get(mission.id);
+  const existingEnd = mission.resolve_at || (activeWorkTimers.get(mission.id)?.endTime);
+
   if (!allMet) {
-    if (existing) {
-      if (existing.timeoutId) clearTimeout(existing.timeoutId);
-      if (existing.intervalId) clearInterval(existing.intervalId);
-      activeWorkTimers.delete(mission.id);
-      persistWorkTimers();
+    if (existingEnd) {
+      await fetch(`/api/missions/${mission.id}/timer`, { method: 'DELETE' });
+      const ex = activeWorkTimers.get(mission.id);
+      if (ex) {
+        if (ex.timeoutId) clearTimeout(ex.timeoutId);
+        if (ex.intervalId) clearInterval(ex.intervalId);
+        activeWorkTimers.delete(mission.id);
+        persistWorkTimers();
+      }
+      mission.resolve_at = null;
       if (openMissionId === mission.id) {
         const tDiv = document.getElementById('missionTimerArea');
         if (tDiv) tDiv.textContent = '';
@@ -2128,48 +2204,17 @@ async function checkMissionCompletion(mission) {
     return;
   }
 
-  if (!existing) {
-    // `mission.timing` is stored as seconds in the DB; ensure at least a
-    // 5‑second window before auto‑resolving a mission.
-    const seconds = Number.isFinite(mission.timing) ? mission.timing : 10;
-    const ms = Math.max(5, seconds) * 1000;
-    const endTime = Date.now() + ms;
-    const tid = setTimeout(async ()=>{
-      const cur = activeWorkTimers.get(mission.id);
-      if (cur && cur.intervalId) clearInterval(cur.intervalId);
-      activeWorkTimers.delete(mission.id);
-      persistWorkTimers();
-      const assignedBefore = await (await fetch(`/api/missions/${mission.id}/units`)).json();
-      await fetch(`/api/missions/${mission.id}/resolve`, { method:'POST' });
-      if (!_stationById || _stationById.size===0) { const stations = await (await fetch('/api/stations')).json(); cacheStations(stations); }
-      for (const u of assignedBefore) {
-        const st = _stationById.get(u.station_id);
-        if (!st) continue;
-        ensureUnitMarker(u);
-        const entry = unitMarkers.get(u.id);
-        const current = entry?.marker.getLatLng() || L.latLng(mission.lat, mission.lon);
-        routeAndAnimateUnit(
-          u.id,
-          [current.lat, current.lng],
-          [st.lat, st.lon],
-          TRAVEL_SPEED[u.class] || 45,
-          () => {
-            const rp = unitRoutes.get(u.id);
-            if (rp) { try { map.removeLayer(rp); } catch {} unitRoutes.delete(u.id); }
-            fetch(`/api/unit-travel/${u.id}`, { method:'DELETE' }).catch(()=>{});
-          },
-          { phase: 'return' }
-        );
-      }
-      await refreshAssignedUnitsUI(mission.id);
+  if (!existingEnd) {
+    const res = await fetch(`/api/missions/${mission.id}/timer`, { method: 'POST' });
+    const data = await res.json().catch(()=>({}));
+    const endTime = Number(data.resolve_at);
+    if (endTime) {
+      mission.resolve_at = endTime;
+      setupTimerForMission(mission, endTime);
       await fetchMissions();
-      const area = document.getElementById('manualDispatchArea');
-      if (area) area.innerHTML = '<strong>Mission resolved.</strong>';
-    }, ms);
-    activeWorkTimers.set(mission.id, { timeoutId: tid, endTime });
-    persistWorkTimers();
-    startMissionCountdown(mission.id, endTime);
-    await fetchMissions();
+    }
+  } else if (mission.resolve_at && (!activeWorkTimers.get(mission.id) || activeWorkTimers.get(mission.id).endTime !== mission.resolve_at)) {
+    setupTimerForMission(mission, mission.resolve_at);
   }
 }
 


### PR DESCRIPTION
## Summary
- store mission resolve deadlines in a new `resolve_at` column
- expose API endpoints to start and clear mission timers and rehydrate them on startup
- sync frontend timers with server state so countdowns survive refreshes

## Testing
- `node --check server.js`
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68aedb59dde88328af7447b0aaef09a1