### PR TITLE
Use unit type icons for default unit markers

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -255,7 +255,9 @@ document.querySelectorAll(".tab-button").forEach(button => {
 });
 
 function unitIconFor(unit) {
-  const url = unit.icon || stationIcons[unit.class] || stationIcons.fire;
+  const sanitizedType = (unit.type || '').replace(/\s+/g, '');
+  const typeIcon = sanitizedType ? `/images/${sanitizedType}.png` : null;
+  const url = unit.icon || typeIcon || stationIcons[unit.class] || stationIcons.fire;
   return makeIcon(url, 24);
 }
 


### PR DESCRIPTION
## Summary
- default unit marker icons now derive from unit type images under `public/images`

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68aef345d88c8328aed61c6dc92e3bbc