### PR TITLE
Prepopulate personnel form with random names

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1013,6 +1013,14 @@ async function showStationDetails(station) {
           <button class="edit-unit-btn" data-unitid="${u.id}">Edit</button>
         </li>`).join('')}
     </ul>`;
+  // Prepopulate personnel input with a random name
+  try {
+    const rnd = await fetch('/api/random-name').then(r => r.json());
+    const input = document.getElementById('personnel-name');
+    if (input && rnd.first && rnd.last) {
+      input.value = `${rnd.first} ${rnd.last}`;
+    }
+  } catch {}
           const iconBtn = detail.querySelector('#change-station-icon');
           iconBtn?.addEventListener('click', async () => {
                 const url = prompt('Enter icon URL:');

--- a/server.js
+++ b/server.js
@@ -3,6 +3,7 @@ const bodyParser = require('body-parser');
 const axios = require('axios');
 const cors = require('cors');
 const path = require('path');
+const { getRandomName } = require('./names');
 
 const db = require('./db');             // your sqlite3 instance
 const unitTypes = require('./unitTypes');
@@ -499,6 +500,16 @@ async function requireFunds(amount) {
 app.get('/api/wallet', async (req, res) => {
   try { res.json({ balance: await getBalance() }); }
   catch (e) { res.status(500).json({ error: e.message }); }
+});
+
+// Provide a random first/last name from names.db
+app.get('/api/random-name', async (req, res) => {
+  try {
+    const { first, last } = await getRandomName();
+    res.json({ first, last });
+  } catch (e) {
+    res.status(500).json({ error: 'Failed to fetch name' });
+  }
 });
 
 /* =========================


### PR DESCRIPTION
## Summary
- Serve a new `/api/random-name` endpoint that returns a random first and last name from `names.db`
- Fetch a random name when opening station details and pre-fill the Add Personnel input

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68af2d1d72cc8328b21fa264082b56d4