### PR TITLE
Fix mission creation on legacy databases

### DIFF
--- a/server.js
+++ b/server.js
@@ -108,6 +108,9 @@ db.serialize(() => {
   db.run(`ALTER TABLE missions ADD COLUMN timing INTEGER DEFAULT 10`, () => { /* ignore if exists */ });
   db.run(`ALTER TABLE missions ADD COLUMN departments TEXT`, () => { /* ignore if exists */ });
   db.run(`ALTER TABLE missions ADD COLUMN resolve_at INTEGER`, () => { /* ignore if exists */ });
+  // Newer schema fields
+  db.run(`ALTER TABLE missions ADD COLUMN penalty_options TEXT DEFAULT '[]'`, () => { /* ignore if exists */ });
+  db.run(`ALTER TABLE missions ADD COLUMN penalties TEXT DEFAULT '[]'`, () => { /* ignore if exists */ });
   db.run(`UPDATE missions SET departments = json_array(department) WHERE departments IS NULL AND department IS NOT NULL`, () => {});
 
   // Mission ↔ Units link


### PR DESCRIPTION
## Summary
- add missing penalty-related columns to legacy `missions` tables
- allow mission insertion without schema errors

## Testing
- `npm test` *(fails: Error: no test specified)*
- `node server.js & curl -X POST http://localhost:911/api/missions`

------
https://chatgpt.com/codex/tasks/task_e_68af618e25d08328bbaaa947c43dc4d8