### PR TITLE
Support responding icons and non-emergency missions

### DIFF
--- a/public/admin.html
+++ b/public/admin.html
@@ -34,6 +34,7 @@
         <th>Patients</th>
         <th>Prisoners</th>
         <th>Rewards</th>
+        <th>Non-Emergency</th>
         <th>Actions</th>
       </tr>
     </thead>

--- a/public/admin.js
+++ b/public/admin.js
@@ -50,6 +50,7 @@ function appendMissionRow(mission) {
     <td>${(mission.patients || []).map(p => p.count ?? `${p.min ?? 0}-${p.max ?? 0}`).join(", ")}</td>
     <td>${(mission.prisoners || []).map(p => p.count ?? `${p.min ?? 0}-${p.max ?? 0}`).join(", ")}</td>
     <td>${Number.isFinite(mission.rewards) ? mission.rewards : 0}</td>
+    <td>${mission.non_emergency ? 'Yes' : 'No'}</td>
     <td><button onclick="editMission(${mission.id})">Edit</button> <button onclick='editRunCard(${JSON.stringify(mission.name)})'>Run Card</button></td>
   `;
   tbody.appendChild(row);
@@ -80,6 +81,7 @@ async function openMissionForm(existing = null) {
     <label>Trigger Filter: <span id="trigger-filter-container"></span></label><br>
     <label>Timing (minutes): <input id="timing" type="number" value="${existing?.timing ?? 0}"></label><br>
     <label>Rewards (currency): <input id="rewards" type="number" value="${existing?.rewards ?? 0}"></label><br>
+    <label>Non-Emergency: <input id="non-emergency" type="checkbox" ${existing?.non_emergency ? 'checked' : ''}></label><br>
 
     <h4>Required Units</h4>
     <div><strong>Type</strong> | <strong>Quantity</strong></div>
@@ -432,7 +434,8 @@ async function submitMission() {
     required_training: collectRows("#training-container") || [],
     modifiers: collectRows("#modifiers-container") || [],
     penalty_options: collectRows("#penalty-container") || [],
-    equipment_required: collectRows("#equipment-container") || []
+    equipment_required: collectRows("#equipment-container") || [],
+    non_emergency: document.getElementById("non-emergency").checked ? 1 : null
   };
 
   const url = id ? `/api/mission-templates/${id}` : `/api/mission-templates`;

--- a/public/index.html
+++ b/public/index.html
@@ -265,8 +265,11 @@ document.querySelectorAll(".tab-button").forEach(button => {
 
 function unitIconFor(unit) {
   const sanitizedType = (unit.type || '').replace(/\s+/g, '');
-  const typeIcon = sanitizedType ? `/images/${sanitizedType}.png` : null;
-  const url = unit.icon || typeIcon || stationIcons[unit.class] || stationIcons.fire;
+  const baseIcon = sanitizedType ? `/images/${sanitizedType}.png` : null;
+  const respDefault = sanitizedType ? `/images/${sanitizedType}-responding.png` : null;
+  const normal = unit.icon || baseIcon || stationIcons[unit.class] || stationIcons.fire;
+  const responding = unit.responding_icon || respDefault || normal;
+  const url = unit.responding ? responding : normal;
   return makeIcon(url, 24);
 }
 
@@ -1856,14 +1859,17 @@ async function showUnitDetails(unitId) {
     });
   });
   content.querySelector('#change-unit-icon')?.addEventListener('click', async () => {
-    const url = prompt('Enter icon URL:');
-    if (!url) return;
-    const res = await fetch(`/api/units/${unitId}/icon`, { method:'PATCH', headers:{'Content-Type':'application/json'}, body: JSON.stringify({ icon: url }) });
+    const url = prompt('Enter icon URL:', unit.icon || '');
+    if (url === null) return;
+    const resp = prompt('Enter responding icon URL (optional):', unit.responding_icon || '');
+    const body = { icon: url };
+    if (resp !== null) body.responding_icon = resp;
+    const res = await fetch(`/api/units/${unitId}/icon`, { method:'PATCH', headers:{'Content-Type':'application/json'}, body: JSON.stringify(body) });
     const data = await res.json();
     if (!res.ok || !data.success) { alert(`Failed: ${data.error || res.statusText}`); return; }
-    _unitById.set(unitId, { ...unit, icon: url });
+    _unitById.set(unitId, { ...unit, icon: url, responding_icon: resp });
     const entry = unitMarkers.get(unitId);
-    if (entry) entry.marker.setIcon(unitIconFor({ ...unit, icon: url }));
+    if (entry) entry.marker.setIcon(unitIconFor({ ...unit, icon: url, responding_icon: resp }));
     modal.style.display = 'none';
     refreshStationPanelNoCache(unit.station_id);
   });


### PR DESCRIPTION
## Summary
- track unit responding state with separate icons for responding and not-responding
- allow mission templates and missions to be marked non-emergency
- expose non-emergency flag in admin UI and mission creation

## Testing
- `npm test` *(fails: Error: no test specified)*
- `node --check server.js`


------
https://chatgpt.com/codex/tasks/task_e_68af648bc524832885f26bfaa24b7ad4