### PR TITLE
Fix recursive mission refresh loop

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -2546,11 +2546,15 @@ async function checkMissionCompletion(mission, assigned) {
           const tDiv = document.getElementById('missionTimerArea');
           if (tDiv) tDiv.textContent = '';
         }
-        await fetchMissions();
+        if (openMissionId === mission.id) {
+          await refreshAssignedUnitsUI(mission.id);
+        }
         return;
       }
     } else {
-      await fetchMissions();
+      if (openMissionId === mission.id) {
+        await refreshAssignedUnitsUI(mission.id);
+      }
       return;
     }
   }
@@ -2584,7 +2588,6 @@ async function checkMissionCompletion(mission, assigned) {
   if (endTime) {
     mission.resolve_at = endTime;
     setupTimerForMission(mission, endTime);
-    await fetchMissions();
   } else if (mission.resolve_at && (!activeWorkTimers.get(mission.id) || activeWorkTimers.get(mission.id).endTime !== mission.resolve_at)) {
     setupTimerForMission(mission, mission.resolve_at);
   }


### PR DESCRIPTION
## Summary
- Avoid recursive `fetchMissions` calls in `checkMissionCompletion` by updating only active mission UI
- Prevent infinite mission refresh and allow missions to open normally

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68af654c5eb08328acd220fe3ab65ae3