### PR TITLE
Limit mission icon size in sidebar

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -25,6 +25,7 @@
 		.hidden { display: none; }
 		.modal-overlay { position: fixed; top: 0; left: 0; width: 100vw; height: 100vh; background: rgba(0,0,0,0.6); display: flex; justify-content: center; align-items: center; z-index: 1000; overflow: auto; }
 		.modal-content { background: white; padding: 2rem; max-width: 90%; max-height: 90%; overflow-y: auto; border-radius: 8px; box-shadow: 0 0 15px rgba(0,0,0,0.3); }
+		.mission-icon { width: 30px; height: 30px; object-fit: contain; vertical-align: middle; }
 	</style>
 </head>
 <body>


### PR DESCRIPTION
## Summary
- Restrict mission list icons to 30x30 for consistent sizing

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68afa7cf571c8328b727dd04be1e4677