### PR TITLE
Add mission frequency weighting

### DIFF
--- a/public/admin.html
+++ b/public/admin.html
@@ -34,6 +34,7 @@
         <th>Patients</th>
         <th>Prisoners</th>
         <th>Rewards</th>
+        <th>Frequency</th>
         <th>Non-Emergency</th>
         <th>Actions</th>
       </tr>

--- a/public/admin.js
+++ b/public/admin.js
@@ -50,6 +50,7 @@ function appendMissionRow(mission) {
     <td>${(mission.patients || []).map(p => p.count ?? `${p.min ?? 0}-${p.max ?? 0}`).join(", ")}</td>
     <td>${(mission.prisoners || []).map(p => p.count ?? `${p.min ?? 0}-${p.max ?? 0}`).join(", ")}</td>
     <td>${Number.isFinite(mission.rewards) ? mission.rewards : 0}</td>
+    <td>${mission.frequency ?? 3}</td>
     <td>${mission.non_emergency ? 'Yes' : 'No'}</td>
     <td><button onclick="editMission(${mission.id})">Edit</button> <button onclick='editRunCard(${JSON.stringify(mission.name)})'>Run Card</button></td>
   `;
@@ -81,6 +82,7 @@ async function openMissionForm(existing = null) {
     <label>Trigger Filter: <span id="trigger-filter-container"></span></label><br>
     <label>Timing (minutes): <input id="timing" type="number" value="${existing?.timing ?? 0}"></label><br>
     <label>Rewards (currency): <input id="rewards" type="number" value="${existing?.rewards ?? 0}"></label><br>
+    <label>Frequency (1-5): <input id="frequency" type="number" min="1" max="5" value="${existing?.frequency ?? 3}"></label><br>
     <label>Non-Emergency: <input id="non-emergency" type="checkbox" ${existing?.non_emergency ? 'checked' : ''}></label><br>
 
     <h4>Required Units</h4>
@@ -435,7 +437,8 @@ async function submitMission() {
     modifiers: collectRows("#modifiers-container") || [],
     penalty_options: collectRows("#penalty-container") || [],
     equipment_required: collectRows("#equipment-container") || [],
-    non_emergency: document.getElementById("non-emergency").checked ? 1 : null
+    non_emergency: document.getElementById("non-emergency").checked ? 1 : null,
+    frequency: Math.min(5, Math.max(1, Number(document.getElementById("frequency").value) || 3))
   };
 
   const url = id ? `/api/mission-templates/${id}` : `/api/mission-templates`;

--- a/public/index.html
+++ b/public/index.html
@@ -531,7 +531,7 @@ async function routeAndAnimateUnit(unitId, from, to, speedClassKmh, onArrive, re
 let missionTemplates = [];
 fetch('/api/mission-templates')
   .then(r => r.json())
-  .then(data => { missionTemplates = data; })
+  .then(data => { missionTemplates = data.map(t => ({ ...t, frequency: Number(t.frequency) || 3 })); })
   .catch(err => console.error('Failed to load mission templates:', err));
 
 // UI helpers
@@ -1635,7 +1635,13 @@ async function generateMission(retry = false, excludeIndex = null) {
     availableTemplates = missionTemplates.filter((_, idx) => idx !== excludeIndex);
     if (!availableTemplates.length) return;
   }
-  const template = availableTemplates[Math.floor(Math.random() * availableTemplates.length)];
+  const weights = availableTemplates.map(t => Math.max(1, 6 - (Number(t.frequency) || 3)));
+  const totalWeight = weights.reduce((a, b) => a + b, 0);
+  let pick = Math.random() * totalWeight;
+  let template = availableTemplates[0];
+  for (let i = 0; i < availableTemplates.length; i++) {
+    if ((pick -= weights[i]) < 0) { template = availableTemplates[i]; break; }
+  }
   const templateIndex = missionTemplates.indexOf(template);
 
   let lat, lon;


### PR DESCRIPTION
## Summary
- add frequency column to mission templates with default 3
- expose and edit mission frequency in admin UI
- weight random mission generation by template frequency

## Testing
- `npm test` (fails: Error: no test specified)
- `node server.js` (fails: SQLITE_ERROR: no such column: responding)


------
https://chatgpt.com/codex/tasks/task_e_68b126171bf4832882b1709349279acd