### PR TITLE
Add basic CAD interface and shared utilities

### DIFF
--- a/public/cad.html
+++ b/public/cad.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>CAD Interface</title>
+  <link rel="stylesheet" href="style.css" />
+  <script type="module" src="js/common.js"></script>
+  <script type="module" src="js/missions.js"></script>
+  <script type="module" src="js/stations.js"></script>
+  <script type="module" src="js/cad.js"></script>
+</head>
+<body class="cad-layout">
+  <div id="cadTop">
+    <button id="returnMain">Return to Main Page</button>
+    <div id="currentCase">Case: N/A</div>
+    <div id="cadSpeeds">
+      <button class="cad-speed" data-speed="pause">Pause</button>
+      <button class="cad-speed" data-speed="slow">Slow</button>
+      <button class="cad-speed" data-speed="medium">Medium</button>
+      <button class="cad-speed" data-speed="fast">Fast</button>
+    </div>
+  </div>
+  <div id="cadContent">
+    <div id="cadMissions"></div>
+    <div id="cadDetail" class="hidden"></div>
+    <div id="cadStations"></div>
+    <div id="cadUnits" class="hidden"></div>
+  </div>
+</body>
+</html>

--- a/public/index.html
+++ b/public/index.html
@@ -9,6 +9,7 @@
         <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/leaflet.draw/1.0.4/leaflet.draw.css" />
         <script src="https://cdnjs.cloudflare.com/ajax/libs/leaflet.draw/1.0.4/leaflet.draw.js"></script>
         <script src="https://cdn.jsdelivr.net/npm/@turf/turf@6/turf.min.js"></script>
+        <script type="module" src="js/common.js"></script>
 	<style>
 		body { margin: 0; display: flex; height: 100vh; font-family: sans-serif; }
 		#sidebar { max-width: 30%; width: 100%; overflow-y: auto; padding: 10px; box-sizing: border-box; }
@@ -31,7 +32,8 @@
 <body>
 
 <div id="sidebar">
-	<h2>Mission Chief Clone</h2>
+        <h2>Mission Chief Clone</h2>
+        <button id="openCad" onclick="location.href='cad.html'" style="margin-bottom:1em;">Open CAD</button>
 	<div style="display: flex; gap: 1em; margin-bottom: 1em;">
                 <button class="tab-button active" data-tab="missions">Missions</button>
                 <button class="tab-button" data-tab="stations">Stations</button>
@@ -183,12 +185,6 @@ function haversineKm(aLat, aLon, bLat, bLon) {
   const la1 = aLat * Math.PI/180, la2 = bLat * Math.PI/180;
   const h = Math.sin(dLat/2)**2 + Math.cos(la1)*Math.cos(la2)*Math.sin(dLon/2)**2;
   return 2*R*Math.asin(Math.sqrt(h));
-}
-
-// Force-fresh GETs to avoid 304s when we need updated data
-function fetchNoCache(url) {
-  const sep = url.includes('?') ? '&' : '?';
-  return fetch(`${url}${sep}t=${Date.now()}`, { cache: 'no-store' });
 }
 
 // Refresh a single station panel with fresh data (no cache)

--- a/public/js/cad.js
+++ b/public/js/cad.js
@@ -1,0 +1,148 @@
+import { fetchNoCache, formatTime } from './common.js';
+import { getMissions, renderMissionRow } from './missions.js';
+import { getStations, renderStationList } from './stations.js';
+
+let cachedMissions = [];
+let cachedStations = [];
+
+async function init() {
+  document.getElementById('returnMain').addEventListener('click', ()=>location.href='index.html');
+  await loadStations();
+  await loadMissions();
+  setInterval(loadMissions, 5000);
+}
+
+async function loadMissions() {
+  cachedMissions = await getMissions();
+  const container = document.getElementById('cadMissions');
+  container.innerHTML = cachedMissions.map(renderMissionRow).join('');
+  container.querySelectorAll('.cad-mission').forEach(div=>{
+    div.addEventListener('click', ()=>openMission(div.dataset.id));
+  });
+}
+
+async function loadStations() {
+  cachedStations = await getStations();
+  const pane = document.getElementById('cadStations');
+  pane.innerHTML = renderStationList(cachedStations);
+  pane.querySelectorAll('.cad-station').forEach(li=>{
+    li.addEventListener('click', ()=>showStation(li.dataset.id));
+  });
+}
+
+async function showStation(id) {
+  const st = await fetchNoCache(`/api/stations/${id}`).then(r=>r.json());
+  const pane = document.getElementById('cadStations');
+  pane.innerHTML = `<div class="cad-station-detail"><div style="text-align:right"><button id="closeStationDetail">Close</button></div><h3>${st.name}</h3><p>Type: ${st.type}</p><p>Department: ${st.department||''}</p></div>`;
+  document.getElementById('closeStationDetail').onclick = loadStations;
+}
+
+function openMission(id) {
+  const mission = cachedMissions.find(m=>String(m.id)===String(id));
+  const pane = document.getElementById('cadDetail');
+  let time = '';
+  if (mission.resolve_at) {
+    const sec = Math.max(0,(mission.resolve_at - Date.now())/1000);
+    time = `<div>Time Remaining: ${formatTime(sec)}</div>`;
+  }
+  pane.innerHTML = `<div style="text-align:right"><button id="closeDetail">Close</button></div>
+    <h3>${mission.type}</h3>
+    ${time}
+    <div>${mission.address||''}</div>
+    <div style="margin-top:8px;">
+      <button id="manualDispatch">Manual Dispatch</button>
+      <button id="autoDispatch">Auto Dispatch</button>
+      <button id="runCardDispatch">Run Card</button>
+    </div>`;
+  pane.classList.remove('hidden');
+  document.getElementById('closeDetail').onclick = ()=>pane.classList.add('hidden');
+  document.getElementById('manualDispatch').onclick = ()=>openManualDispatch(mission);
+  document.getElementById('autoDispatch').onclick = ()=>autoDispatch(mission);
+  document.getElementById('runCardDispatch').onclick = ()=>runCardDispatch(mission);
+}
+
+async function autoDispatch(mission) {
+  // Simple auto dispatch: pick first available units matching required types
+  const [stations, units] = await Promise.all([
+    getStations(),
+    fetchNoCache('/api/units?status=available').then(r=>r.json())
+  ]);
+  const stMap = new Map(stations.map(s=>[s.id,s]));
+  const missionDepts = Array.isArray(mission.departments) ? mission.departments : [];
+  const available = units.filter(u=>{
+    const st = stMap.get(u.station_id);
+    return u.status==='available' && (missionDepts.length===0 || (st && missionDepts.includes(st.department)));
+  });
+  const reqs = Array.isArray(mission.required_units) ? mission.required_units : [];
+  const selected = [];
+  reqs.forEach(r=>{
+    const need = r.quantity ?? r.count ?? r.qty ?? 1;
+    const matches = available.filter(u=>u.type===r.type && !selected.includes(u)).slice(0, need);
+    selected.push(...matches);
+  });
+  await dispatchUnits(mission.id, selected.map(u=>u.id));
+  await loadMissions();
+}
+
+async function runCardDispatch(mission) {
+  try {
+    const rc = await fetchNoCache(`/api/run-cards/${encodeURIComponent(mission.type)}`).then(r=>r.json());
+    const unitTypes = rc.units || [];
+    const units = await fetchNoCache('/api/units?status=available').then(r=>r.json());
+    const selected = [];
+    unitTypes.forEach(t=>{
+      const match = units.find(u=>u.type===t && !selected.includes(u));
+      if (match) selected.push(match);
+    });
+    await dispatchUnits(mission.id, selected.map(u=>u.id));
+    await loadMissions();
+  } catch(e) {
+    console.error(e);
+  }
+}
+
+async function dispatchUnits(missionId, unitIds) {
+  for (const id of unitIds) {
+    await fetch('/api/mission-units', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ mission_id: missionId, unit_id: id })
+    });
+  }
+}
+
+async function openManualDispatch(mission) {
+  const unitsPane = document.getElementById('cadUnits');
+  const [stations, units] = await Promise.all([
+    getStations(),
+    fetchNoCache('/api/units').then(r=>r.json())
+  ]);
+  const stMap = new Map(stations.map(s=>[s.id,s]));
+  const available = units.filter(u=>u.status==='available');
+  const groups = {};
+  available.forEach(u=>{
+    const st = stMap.get(u.station_id);
+    const dept = st?.department || 'Unknown';
+    if (!groups[dept]) groups[dept] = [];
+    groups[dept].push(u);
+  });
+  let html = '<div class="cad-unit-header"><button id="dispatchUnits">Dispatch</button><button id="closeUnits">Close</button></div>';
+  for (const dept of Object.keys(groups).sort()) {
+    html += `<h4>${dept}</h4><ul>`;
+    for (const u of groups[dept].sort((a,b)=>a.name.localeCompare(b.name))) {
+      html += `<li><label><input type="checkbox" value="${u.id}"> ${u.name}</label></li>`;
+    }
+    html += '</ul>';
+  }
+  unitsPane.innerHTML = html;
+  unitsPane.classList.add('active');
+  document.getElementById('closeUnits').onclick = ()=>unitsPane.classList.remove('active');
+  document.getElementById('dispatchUnits').onclick = async ()=>{
+    const ids = Array.from(unitsPane.querySelectorAll('input[type=checkbox]:checked')).map(c=>Number(c.value));
+    await dispatchUnits(mission.id, ids);
+    unitsPane.classList.remove('active');
+    await loadMissions();
+  };
+}
+
+document.addEventListener('DOMContentLoaded', init);

--- a/public/js/common.js
+++ b/public/js/common.js
@@ -1,0 +1,32 @@
+// Common utility functions shared across front-end pages
+// Provides helpers for fetching without cache and formatting time
+
+// Force-fresh GETs to avoid cached responses
+export async function fetchNoCache(url) {
+  const sep = url.includes('?') ? '&' : '?';
+  const res = await fetch(`${url}${sep}t=${Date.now()}`, { cache: 'no-store' });
+  return res;
+}
+
+// Compute haversine distance in kilometers
+export function haversineKm(aLat, aLon, bLat, bLon) {
+  const R = 6371;
+  const dLat = (bLat - aLat) * Math.PI / 180;
+  const dLon = (bLon - aLon) * Math.PI / 180;
+  const la1 = aLat * Math.PI / 180, la2 = bLat * Math.PI / 180;
+  const h = Math.sin(dLat/2)**2 + Math.cos(la1)*Math.cos(la2)*Math.sin(dLon/2)**2;
+  return 2 * R * Math.asin(Math.sqrt(h));
+}
+
+// Helper to format seconds as M:SS
+export function formatTime(seconds) {
+  const s = Math.max(0, Math.floor(seconds));
+  const m = Math.floor(s / 60);
+  const sec = s % 60;
+  return `${m}:${sec.toString().padStart(2, '0')}`;
+}
+
+// Expose helpers globally for legacy scripts
+window.fetchNoCache = fetchNoCache;
+window.haversineKm = haversineKm;
+window.formatTime = formatTime;

--- a/public/js/missions.js
+++ b/public/js/missions.js
@@ -1,0 +1,37 @@
+import { fetchNoCache, formatTime } from './common.js';
+
+// Fetch all missions from API and sort by warning level and remaining time
+export async function getMissions() {
+  const missions = await fetchNoCache('/api/missions').then(r => r.json());
+  return sortMissions(missions);
+}
+
+export function sortMissions(missions) {
+  const level = m => {
+    if (m.warning3) return 3;
+    if (m.warning2) return 2;
+    if (m.warning1) return 1;
+    return 0;
+  };
+  return missions.slice().sort((a,b)=>{
+    const diff = level(b) - level(a);
+    if (diff !== 0) return diff;
+    const ta = a.resolve_at ? a.resolve_at : 0;
+    const tb = b.resolve_at ? b.resolve_at : 0;
+    return ta - tb;
+  });
+}
+
+export function renderMissionRow(mission) {
+  const lvl = mission.warning3 ? 3 : mission.warning2 ? 2 : mission.warning1 ? 1 : 1;
+  const icon = `/warning${lvl}.png`;
+  let time = '';
+  if (mission.resolve_at) {
+    const sec = Math.max(0, (mission.resolve_at - Date.now())/1000);
+    time = ` - ${formatTime(sec)}`;
+  }
+  return `<div class="cad-mission" data-id="${mission.id}"><img src="${icon}" class="cad-icon"/> ${mission.type || 'Mission'}${time}<div class="cad-address">${mission.address || ''}</div></div>`;
+}
+
+// Expose globally
+window.missionUtils = { getMissions, renderMissionRow };

--- a/public/js/stations.js
+++ b/public/js/stations.js
@@ -1,0 +1,31 @@
+import { fetchNoCache } from './common.js';
+
+export async function getStations() {
+  return fetchNoCache('/api/stations').then(r=>r.json());
+}
+
+export function groupStationsByDept(stations) {
+  const groups = {};
+  stations.forEach(st => {
+    const dept = st.department || 'Unknown';
+    if (!groups[dept]) groups[dept] = [];
+    groups[dept].push(st);
+  });
+  Object.keys(groups).forEach(k=>groups[k].sort((a,b)=>a.name.localeCompare(b.name)));
+  return groups;
+}
+
+export function renderStationList(stations) {
+  const groups = groupStationsByDept(stations);
+  let html = '';
+  for (const dept of Object.keys(groups).sort()) {
+    html += `<div class="cad-dept"><h4>${dept}</h4><ul>`;
+    for (const st of groups[dept]) {
+      html += `<li class="cad-station" data-id="${st.id}">${st.name}</li>`;
+    }
+    html += '</ul></div>';
+  }
+  return html;
+}
+
+window.stationUtils = { getStations, renderStationList };

--- a/public/style.css
+++ b/public/style.css
@@ -47,3 +47,94 @@ h3 {
     padding: 15px;
     clear:both;
 }
+
+/* CAD interface layout */
+.cad-layout {
+    margin:0;
+    height:100vh;
+    display:flex;
+    flex-direction:column;
+    font-family: sans-serif;
+}
+
+#cadTop {
+    background:#111;
+    color:#fff;
+    padding:5px;
+    display:flex;
+    gap:1em;
+    align-items:center;
+}
+
+#cadContent {
+    flex:1;
+    display:grid;
+    grid-template-rows:1fr 1fr;
+    grid-template-columns:1fr 1fr;
+    height:100%;
+}
+
+#cadMissions {
+    grid-row:1;
+    grid-column:1 / span 2;
+    overflow-y:auto;
+    border-bottom:1px solid #ccc;
+}
+
+#cadDetail {
+    grid-row:2;
+    grid-column:1;
+    background:#000;
+    color:#fff;
+    overflow-y:auto;
+    padding:8px;
+}
+
+#cadStations {
+    grid-row:2;
+    grid-column:2;
+    overflow-y:auto;
+    padding:8px;
+    background:#f5f5f5;
+}
+
+#cadUnits {
+    grid-row:2;
+    grid-column:2;
+    overflow-y:auto;
+    padding:8px;
+    background:#fff;
+}
+
+#cadUnits.hidden,
+#cadDetail.hidden {
+    display:none;
+}
+
+.cad-mission {
+    padding:4px;
+    border-bottom:1px solid #ccc;
+    cursor:pointer;
+}
+
+.cad-mission:hover {
+    background:#eee;
+}
+
+.cad-icon {
+    width:20px;
+    height:20px;
+    vertical-align:middle;
+}
+
+.cad-address {
+    font-size:0.85em;
+    margin-left:25px;
+    color:#555;
+}
+
+.cad-unit-header {
+    display:flex;
+    justify-content:space-between;
+    margin-bottom:8px;
+}


### PR DESCRIPTION
## Summary
- Add navigation button from main page to new CAD interface
- Build CAD layout with mission list, station browser, and dispatch panes
- Introduce shared front-end utilities and modules for missions and stations
- Style CAD grid and support manual and auto dispatch workflows

## Testing
- `npm test` (fails: Error: no test specified)


------
https://chatgpt.com/codex/tasks/task_e_68b127ca3178832897a4d13f5b057af9