### PR TITLE
Enhance CAD mission display and station management

### DIFF
--- a/public/cad.html
+++ b/public/cad.html
@@ -12,7 +12,7 @@
 <body class="cad-layout">
   <div id="cadTop">
     <button id="returnMain">Return to Main Page</button>
-    <div id="currentCase">Case: N/A</div>
+    <div id="walletDisplay">Balance: $0</div>
     <div id="cadSpeeds">
       <button class="cad-speed" data-speed="pause">Pause</button>
       <button class="cad-speed" data-speed="slow">Slow</button>

--- a/public/js/cad.js
+++ b/public/js/cad.js
@@ -7,13 +7,22 @@ let cachedStations = [];
 
 async function init() {
   document.getElementById('returnMain').addEventListener('click', ()=>location.href='index.html');
+  await updateWallet();
   await loadStations();
   await loadMissions();
   setInterval(loadMissions, 5000);
 }
 
+async function updateWallet() {
+  try {
+    const w = await fetchNoCache('/api/wallet').then(r=>r.json());
+    document.getElementById('walletDisplay').textContent = `Balance: $${w.balance}`;
+  } catch {}
+}
+
 async function loadMissions() {
   cachedMissions = await getMissions();
+  await updateWallet();
   const container = document.getElementById('cadMissions');
   container.innerHTML = cachedMissions.map(renderMissionRow).join('');
   container.querySelectorAll('.cad-mission').forEach(div=>{
@@ -31,31 +40,64 @@ async function loadStations() {
 }
 
 async function showStation(id) {
-  const st = await fetchNoCache(`/api/stations/${id}`).then(r=>r.json());
+  const [st, units, unassigned] = await Promise.all([
+    fetchNoCache(`/api/stations/${id}`).then(r=>r.json()),
+    fetchNoCache(`/api/units?station_id=${id}`).then(r=>r.json()),
+    fetchNoCache(`/api/stations/${id}/personnel`).then(r=>r.json()).catch(()=>[])
+  ]);
   const pane = document.getElementById('cadStations');
-  pane.innerHTML = `<div class="cad-station-detail"><div style="text-align:right"><button id="closeStationDetail">Close</button></div><h3>${st.name}</h3><p>Type: ${st.type}</p><p>Department: ${st.department||''}</p></div>`;
+  const personnel = [];
+  units.forEach(u => (u.personnel || []).forEach(p => personnel.push({ ...p, unit: u.name })));
+  unassigned.forEach(p => personnel.push({ ...p, unit: 'Unassigned' }));
+  let html = `<div class="cad-station-detail"><div style="text-align:right"><button id="closeStationDetail">Close</button></div><h3>${st.name}</h3><p>Type: ${st.type}</p><p>Department: ${st.department||''}</p>`;
+  html += `<div style="margin:8px 0;"><button id="newPersonnel">New Personnel</button> <button id="newUnit">New Unit</button> <button id="newEquipment">New Equipment</button></div>`;
+  html += `<div style="display:flex; gap:20px;"><div><h4>Units</h4><ul>`;
+  html += units.map(u => `<li class="cad-unit" data-id="${u.id}">${u.name}</li>`).join('');
+  html += `</ul></div><div><h4>Personnel</h4><ul>`;
+  html += personnel.map(p => `<li class="cad-personnel" data-id="${p.id}">${p.name} - ${p.unit}</li>`).join('');
+  html += `</ul></div></div></div>`;
+  pane.innerHTML = html;
   document.getElementById('closeStationDetail').onclick = loadStations;
+  document.getElementById('newPersonnel').onclick = () => alert('Not implemented');
+  document.getElementById('newUnit').onclick = () => alert('Not implemented');
+  document.getElementById('newEquipment').onclick = () => alert('Not implemented');
+  pane.querySelectorAll('.cad-unit').forEach(li => li.addEventListener('click', () => alert(`Edit unit ${li.dataset.id}`)));
+  pane.querySelectorAll('.cad-personnel').forEach(li => li.addEventListener('click', () => alert(`Edit personnel ${li.dataset.id}`)));
 }
 
-function openMission(id) {
+async function openMission(id) {
   const mission = cachedMissions.find(m=>String(m.id)===String(id));
   const pane = document.getElementById('cadDetail');
+  const assigned = await fetchNoCache(`/api/missions/${id}/units`).then(r=>r.json()).catch(()=>[]);
   let time = '';
   if (mission.resolve_at) {
     const sec = Math.max(0,(mission.resolve_at - Date.now())/1000);
     time = `<div>Time Remaining: ${formatTime(sec)}</div>`;
   }
+  let reqHtml = '';
+  if (Array.isArray(mission.required_units) && mission.required_units.length) {
+    reqHtml = '<div><strong>Required Units:</strong><ul>' + mission.required_units.map(r=>`<li>${r.quantity ?? r.count ?? r.qty ?? 1} ${r.type}</li>`).join('') + '</ul></div>';
+  }
+  let assignedHtml = '';
+  if (assigned.length) {
+    assignedHtml = '<div style="margin-top:8px;"><strong>Assigned Units:</strong><ul>' + assigned.map(u=>`<li>${u.name} - ${u.status}</li>`).join('') + '</ul></div>';
+  }
   pane.innerHTML = `<div style="text-align:right"><button id="closeDetail">Close</button></div>
     <h3>${mission.type}</h3>
     ${time}
     <div>${mission.address||''}</div>
+    ${reqHtml}
+    ${assignedHtml}
     <div style="margin-top:8px;">
       <button id="manualDispatch">Manual Dispatch</button>
       <button id="autoDispatch">Auto Dispatch</button>
       <button id="runCardDispatch">Run Card</button>
     </div>`;
   pane.classList.remove('hidden');
-  document.getElementById('closeDetail').onclick = ()=>pane.classList.add('hidden');
+  document.getElementById('closeDetail').onclick = ()=>{
+    pane.classList.add('hidden');
+    document.getElementById('cadUnits').classList.add('hidden');
+  };
   document.getElementById('manualDispatch').onclick = ()=>openManualDispatch(mission);
   document.getElementById('autoDispatch').onclick = ()=>autoDispatch(mission);
   document.getElementById('runCardDispatch').onclick = ()=>runCardDispatch(mission);
@@ -135,12 +177,12 @@ async function openManualDispatch(mission) {
     html += '</ul>';
   }
   unitsPane.innerHTML = html;
-  unitsPane.classList.add('active');
-  document.getElementById('closeUnits').onclick = ()=>unitsPane.classList.remove('active');
+  unitsPane.classList.remove('hidden');
+  document.getElementById('closeUnits').onclick = ()=>unitsPane.classList.add('hidden');
   document.getElementById('dispatchUnits').onclick = async ()=>{
     const ids = Array.from(unitsPane.querySelectorAll('input[type=checkbox]:checked')).map(c=>Number(c.value));
     await dispatchUnits(mission.id, ids);
-    unitsPane.classList.remove('active');
+    unitsPane.classList.add('hidden');
     await loadMissions();
   };
 }

--- a/public/js/missions.js
+++ b/public/js/missions.js
@@ -8,18 +8,19 @@ export async function getMissions() {
 
 export function sortMissions(missions) {
   const level = m => {
-    if (m.warning3) return 3;
-    if (m.warning2) return 2;
     if (m.warning1) return 1;
-    return 0;
+    if (m.warning2) return 2;
+    if (m.warning3) return 3;
+    return 4;
   };
-  return missions.slice().sort((a,b)=>{
-    const diff = level(b) - level(a);
-    if (diff !== 0) return diff;
-    const ta = a.resolve_at ? a.resolve_at : 0;
-    const tb = b.resolve_at ? b.resolve_at : 0;
-    return ta - tb;
-  });
+  return missions
+    .filter(m => m.status !== 'resolved')
+    .slice()
+    .sort((a, b) => {
+      const diff = level(a) - level(b);
+      if (diff !== 0) return diff;
+      return (a.id || 0) - (b.id || 0);
+    });
 }
 
 export function renderMissionRow(mission) {


### PR DESCRIPTION
## Summary
- Show wallet balance on CAD screen
- Filter resolved missions and sort active missions by warning level then age
- Expand CAD mission and station panels with richer details and manual dispatch fixes

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68b12c134fcc8328b074c5511e6997d1