### PR TITLE
Fix mission summary table alignment in admin panel

### DIFF
--- a/public/admin.html
+++ b/public/admin.html
@@ -24,7 +24,6 @@
         <th>Name</th>
         <th>Trigger Type</th>
         <th>Trigger Filter</th>
-        <th>Department</th>
         <th>Timing</th>
         <th>Required Units</th>
         <th>Required Training</th>


### PR DESCRIPTION
## Summary
- Remove unused Department column from admin mission summary table so columns line up with displayed mission data

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68b13014f9988328957b99209e500914