### PR TITLE
Enable creation of station assets from CAD view

### DIFF
--- a/public/cad.html
+++ b/public/cad.html
@@ -4,6 +4,9 @@
   <meta charset="UTF-8" />
   <title>CAD Interface</title>
   <link rel="stylesheet" href="style.css" />
+  <script src="/config/unitTypes.js"></script>
+  <script src="/config/trainings.js"></script>
+  <script src="/config/equipment.js"></script>
   <script type="module" src="js/common.js"></script>
   <script type="module" src="js/missions.js"></script>
   <script type="module" src="js/stations.js"></script>


### PR DESCRIPTION
## Summary
- allow creating personnel, units, and station equipment directly from CAD station pane
- include config scripts in CAD page to reuse training, equipment, and unit data

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68b17c2fa34883288b51fe28c9845c34