### PR TITLE
refactor: share edit dialogs

### DIFF
--- a/public/cad.html
+++ b/public/cad.html
@@ -10,6 +10,7 @@
   <script type="module" src="js/common.js"></script>
   <script type="module" src="js/missions.js"></script>
   <script type="module" src="js/stations.js"></script>
+  <script type="module" src="js/edit-dialogs.js"></script>
   <script type="module" src="js/cad.js"></script>
 </head>
 <body class="cad-layout">
@@ -28,6 +29,28 @@
     <div id="cadDetail" class="hidden"></div>
     <div id="cadStations"></div>
     <div id="cadUnits" class="hidden"></div>
+  </div>
+
+  <!-- Edit Personnel Modal -->
+  <div id="editPersonnelModal" style="
+        position: fixed; top: 20%; left: 50%; transform: translateX(-50%);
+        background: white; border: 2px solid #444; padding: 1em;
+        width: 300px; box-shadow: 0 0 10px rgba(0,0,0,0.3);
+        display: none; z-index: 10001;">
+        <h3>Edit Personnel</h3>
+        <div id="editPersonnelContent">Loading...</div>
+        <button onclick="document.getElementById('editPersonnelModal').style.display = 'none';">Close</button>
+  </div>
+
+  <!-- Edit Unit Modal -->
+  <div id="editUnitModal" style="
+        position: fixed; top: 20%; left: 50%; transform: translateX(-50%);
+        background: white; border: 2px solid #444; padding: 1em;
+        width: 300px; box-shadow: 0 0 10px rgba(0,0,0,0.3);
+        display: none; z-index: 10001;">
+        <h3>Edit Unit</h3>
+        <div id="editUnitContent">Loading...</div>
+        <button onclick="document.getElementById('editUnitModal').style.display = 'none';">Close</button>
   </div>
 </body>
 </html>

--- a/public/index.html
+++ b/public/index.html
@@ -10,6 +10,7 @@
         <script src="https://cdnjs.cloudflare.com/ajax/libs/leaflet.draw/1.0.4/leaflet.draw.js"></script>
         <script src="https://cdn.jsdelivr.net/npm/@turf/turf@6/turf.min.js"></script>
         <script type="module" src="js/common.js"></script>
+        <script type="module" src="js/edit-dialogs.js"></script>
 	<style>
 		body { margin: 0; display: flex; height: 100vh; font-family: sans-serif; }
 		#sidebar { max-width: 30%; width: 100%; overflow-y: auto; padding: 10px; box-sizing: border-box; }
@@ -1354,136 +1355,13 @@ async function showStationDetails(station) {
 
         // Replace inline editPersonnel with safe listener
         detail.querySelectorAll('#personnel-list button').forEach(btn => {
-	  const m = btn.getAttribute('onclick');
-	  if (m && m.startsWith('editPersonnel(')) {
-		btn.removeAttribute('onclick');
-		const id = parseInt(m.match(/editPersonnel\((\d+)\)/)[1], 10);
-		btn.addEventListener('click', () => window.editPersonnel(id));
-	  }
-	});
-	window.editPersonnel = editPersonnel;
-
-  // ==== Edit Personnel Modal (prefill + robust save) ====
-	function openPersonnelModal(person) {
-	  const modal = document.getElementById('editPersonnelModal');
-	  const content = document.getElementById('editPersonnelContent');
-
-	  const st = station || window.currentStation || {};
-	  const availableTrainings = getTrainingsForClass(st.type);
-
-	  const currentName = (person && person.name) ? person.name : '';
-	  const currentTraining = Array.isArray(person?.training) ? person.training : [];
-	  const curSet = new Set(currentTraining.map(t => String(t).toLowerCase()));
-
-	  content.innerHTML = `
-		<div style="display:flex; flex-direction:column; gap:10px;">
-		  <label>
-			<div>Name</div>
-			<input id="edit-personnel-name" type="text" style="width:100%;" value="${currentName.replace(/"/g, '&quot;')}" />
-		  </label>
-
-		  <div>
-			<div>Training</div>
-			<div id="edit-training-list" style="max-height:160px; overflow:auto; padding:6px; border:1px solid #ddd; border-radius:6px;">
-                            ${
-                                  availableTrainings.length
-                                    ? availableTrainings.map(t => {
-                                            const name = typeof t === 'string' ? t : t.name;
-                                            const checked = curSet.has(String(name).toLowerCase()) ? 'checked' : '';
-                                            return `<label style="display:block;"><input type="checkbox" value="${name}" ${checked}> ${name}</label>`;
-                                          }).join('')
-                                    : '<em>No training list available for this station type.</em>'
-                            }
-			</div>
-		  </div>
-
-		  <div style="display:flex; gap:8px; justify-content:flex-end;">
-			<button id="edit-personnel-cancel" type="button">Cancel</button>
-			<button id="edit-personnel-save" type="button" style="background:#0b5; color:#fff;">Save</button>
-		  </div>
-		</div>
-	  `;
-
-	  // Wire buttons
-	  content.querySelector('#edit-personnel-cancel').onclick = () => { modal.style.display = 'none'; };
-
-	  content.querySelector('#edit-personnel-save').onclick = async () => {
-	    const nameEl = content.querySelector('#edit-personnel-name');
-	    const name = (nameEl?.value || '').trim();
-
-	    const selectedTrainings = Array.from(
-		  content.querySelectorAll('#edit-training-list input[type=checkbox]:checked')
-	    ).map(cb => cb.value);
-
-      // Build a payload that many backends accept
-      const payload = {
-        id: person.id,
-        station_id: (station && station.id) || person.station_id,
-        name,
-        training: selectedTrainings
-      };
-      const urlBase = `/api/personnel/${person.id}`;
-
-      // Try common update styles until one succeeds
-      const attempts = [
-        { method: 'PATCH', url: urlBase, body: payload },
-        { method: 'PUT',   url: urlBase, body: payload },
-        { method: 'POST',  url: `${urlBase}?_method=PATCH`, body: payload },
-        { method: 'POST',  url: `${urlBase}?_method=PUT`,   body: payload },
-        { method: 'POST',  url: urlBase, body: payload, headers: { 'X-HTTP-Method-Override': 'PATCH' } },
-        { method: 'POST',  url: urlBase, body: payload, headers: { 'X-HTTP-Method-Override': 'PUT' } },
-        { method: 'POST',  url: `/api/personnel/update`, body: payload },
-      ];
-
-      let ok = false, lastStatus = 0, lastText = '';
-      for (const a of attempts) {
-        try {
-          const res = await fetch(a.url, {
-            method: a.method,
-            headers: { 'Content-Type': 'application/json', ...(a.headers || {}) },
-            body: JSON.stringify(a.body),
-            cache: 'no-store'
-          });
-          lastStatus = res.status;
-          lastText = await res.text().catch(()=>'');
-
-          if (res.ok || [200,201,202,204].includes(res.status)) {
-            ok = true;
-            console.log(`[save] Success via ${a.method} ${a.url} — status ${res.status}`, lastText.slice(0,120));
-            break;
-          } else {
-            console.warn(`[save] Failed via ${a.method} ${a.url} — status ${res.status}`, lastText.slice(0,120));
+          const m = btn.getAttribute('onclick');
+          if (m && m.startsWith('editPersonnel(')) {
+                btn.removeAttribute('onclick');
+                const id = parseInt(m.match(/editPersonnel\((\d+)\)/)[1], 10);
+                btn.addEventListener('click', () => window.editPersonnel(id));
           }
-        } catch (e) {
-          lastText = e?.message || String(e);
-          console.warn(`[save] Network error via ${a.method} ${a.url}:`, lastText);
-        }
-      }
-
-      if (!ok) {
-        alert(`Failed to save personnel changes.\nLast response (${lastStatus}): ${lastText}`);
-        return;
-      }
-
-      // Close and refresh the station panel with uncached GETs
-      modal.style.display = 'none';
-      await refreshStationPanelNoCache(station.id);
-	  };
-
-    modal.style.display = 'block';
-	}
-
-	// expose globally for inline paths
-        window.openPersonnelModal = openPersonnelModal;
-
-        function editPersonnel(id) {
-          fetch(`/api/personnel/${id}`)
-                .then(res => res.json())
-                .then(person => {
-                  openPersonnelModal(person);
-                });
-        }
-
+        });
   document.getElementById('create-unit').addEventListener('click', async ()=>{
     const type = document.getElementById('unit-type').value;
     const name = document.getElementById('unit-name').value;
@@ -1517,71 +1395,6 @@ async function showStationDetails(station) {
 
   refreshBayInfo(station.id);
 }
-
-// ==== Edit Unit Modal ====
-function openUnitModal(unit) {
-  const modal = document.getElementById('editUnitModal');
-  const content = document.getElementById('editUnitContent');
-  const currentName = unit?.name || '';
-  const currentPrio = Number(unit?.priority) || 1;
-
-  content.innerHTML = `
-    <div style="display:flex; flex-direction:column; gap:10px;">
-      <label>
-        <div>Name</div>
-        <input id="edit-unit-name" type="text" style="width:100%;" value="${currentName.replace(/"/g,'&quot;')}" />
-      </label>
-      <label>
-        <div>Priority (1-5)</div>
-        <input id="edit-unit-priority" type="number" min="1" max="5" value="${currentPrio}" />
-      </label>
-      <div style="display:flex; gap:8px; justify-content:flex-end;">
-        <button id="edit-unit-cancel" type="button">Cancel</button>
-        <button id="edit-unit-save" type="button" style="background:#0b5; color:#fff;">Save</button>
-      </div>
-    </div>`;
-
-  content.querySelector('#edit-unit-cancel').onclick = () => { modal.style.display = 'none'; };
-
-  content.querySelector('#edit-unit-save').onclick = async () => {
-    const nameEl = content.querySelector('#edit-unit-name');
-    const name = (nameEl?.value || '').trim();
-    const prEl = content.querySelector('#edit-unit-priority');
-    let priority = Number(prEl?.value);
-    if (!Number.isFinite(priority)) priority = 1;
-    priority = Math.min(5, Math.max(1, priority));
-    const payload = { name, priority };
-    const urlBase = `/api/units/${unit.id}`;
-    const attempts = [
-      { method:'PATCH', url:urlBase, body:payload },
-      { method:'PUT', url:urlBase, body:payload },
-      { method:'POST', url:`${urlBase}?_method=PATCH`, body:payload },
-      { method:'POST', url:`${urlBase}?_method=PUT`, body:payload },
-      { method:'POST', url:urlBase, body:payload, headers:{'X-HTTP-Method-Override':'PATCH'} },
-      { method:'POST', url:urlBase, body:payload, headers:{'X-HTTP-Method-Override':'PUT'} },
-      { method:'POST', url:'/api/units/update', body:{ id:unit.id, ...payload } }
-    ];
-    let ok=false,lastStatus=0,lastText='';
-    for(const a of attempts){
-      try{
-        const res=await fetch(a.url,{method:a.method,headers:{'Content-Type':'application/json',...(a.headers||{})},body:JSON.stringify(a.body),cache:'no-store'});
-        lastStatus=res.status; lastText=await res.text().catch(()=> '');
-        if(res.ok||[200,201,202,204].includes(res.status)){ ok=true; break; }
-      }catch(e){ lastText=e?.message||String(e); }
-    }
-    if(!ok){ alert(`Failed to save unit changes.\nLast response (${lastStatus}): ${lastText}`); return; }
-    modal.style.display='none';
-    await refreshStationPanelNoCache(unit.station_id);
-  };
-
-  modal.style.display = 'block';
-}
-
-function editUnit(id){
-  const u=_unitById.get(id);
-  if(u) openUnitModal(u);
-}
-window.editUnit = editUnit;
 
 // Build station
 document.getElementById("buildStation").addEventListener("click", () => { buildStationMode = true; alert("Click the map to place your new station"); });

--- a/public/js/cad.js
+++ b/public/js/cad.js
@@ -1,6 +1,7 @@
 import { fetchNoCache, formatTime } from './common.js';
 import { getMissions, renderMissionRow } from './missions.js';
 import { getStations, renderStationList } from './stations.js';
+import { editUnit, editPersonnel } from './edit-dialogs.js';
 
 let missionTemplates = [];
 fetch('/api/mission-templates')
@@ -121,6 +122,7 @@ async function showStation(id) {
     fetchNoCache(`/api/units?station_id=${id}`).then(r=>r.json()),
     fetchNoCache(`/api/stations/${id}/personnel`).then(r=>r.json()).catch(()=>[])
   ]);
+  window.currentStation = st;
   const pane = document.getElementById('cadStations');
   const personnel = [];
   units.forEach(u => (u.personnel || []).forEach(p => personnel.push({ ...p, unit: u.name })));
@@ -137,9 +139,11 @@ async function showStation(id) {
   document.getElementById('newPersonnel').onclick = () => openNewPersonnel(st);
   document.getElementById('newUnit').onclick = () => openNewUnit(st);
   document.getElementById('newEquipment').onclick = () => openNewEquipment(st);
-  pane.querySelectorAll('.cad-unit').forEach(li => li.addEventListener('click', () => alert(`Edit unit ${li.dataset.id}`)));
-  pane.querySelectorAll('.cad-personnel').forEach(li => li.addEventListener('click', () => alert(`Edit personnel ${li.dataset.id}`)));
+  pane.querySelectorAll('.cad-unit').forEach(li => li.addEventListener('click', () => editUnit(Number(li.dataset.id))));
+  pane.querySelectorAll('.cad-personnel').forEach(li => li.addEventListener('click', () => editPersonnel(Number(li.dataset.id))));
 }
+
+window.refreshStationPanelNoCache = showStation;
 
 function getTrainingsForClass(cls) {
   const key = String(cls || '').toLowerCase();

--- a/public/js/edit-dialogs.js
+++ b/public/js/edit-dialogs.js
@@ -1,0 +1,153 @@
+export function openPersonnelModal(person, station) {
+  const modal = document.getElementById('editPersonnelModal');
+  const content = document.getElementById('editPersonnelContent');
+  const st = station || window.currentStation || {};
+  const getTrainings = typeof getTrainingsForClass === 'function' ? getTrainingsForClass : () => [];
+  const availableTrainings = getTrainings(st.type);
+  const currentName = person?.name || '';
+  const currentTraining = Array.isArray(person?.training) ? person.training : [];
+  const curSet = new Set(currentTraining.map(t => String(t).toLowerCase()));
+  content.innerHTML = `
+    <div style="display:flex; flex-direction:column; gap:10px;">
+      <label>
+        <div>Name</div>
+        <input id="edit-personnel-name" type="text" style="width:100%;" value="${currentName.replace(/"/g, '&quot;')}" />
+      </label>
+      <div>
+        <div>Training</div>
+        <div id="edit-training-list" style="max-height:160px; overflow:auto; padding:6px; border:1px solid #ddd; border-radius:6px;">
+          ${
+            availableTrainings.length
+              ? availableTrainings.map(t => {
+                  const name = typeof t === 'string' ? t : t.name;
+                  const checked = curSet.has(String(name).toLowerCase()) ? 'checked' : '';
+                  return `<label style="display:block;"><input type="checkbox" value="${name}" ${checked}> ${name}</label>`;
+                }).join('')
+              : '<em>No training list available for this station type.</em>'
+          }
+        </div>
+      </div>
+      <div style="display:flex; gap:8px; justify-content:flex-end;">
+        <button id="edit-personnel-cancel" type="button">Cancel</button>
+        <button id="edit-personnel-save" type="button" style="background:#0b5; color:#fff;">Save</button>
+      </div>
+    </div>
+  `;
+  content.querySelector('#edit-personnel-cancel').onclick = () => { modal.style.display = 'none'; };
+  content.querySelector('#edit-personnel-save').onclick = async () => {
+    const nameEl = content.querySelector('#edit-personnel-name');
+    const name = (nameEl?.value || '').trim();
+    const selectedTrainings = Array.from(content.querySelectorAll('#edit-training-list input[type=checkbox]:checked')).map(cb => cb.value);
+    const payload = { id: person.id, station_id: (station && station.id) || person.station_id, name, training: selectedTrainings };
+    const urlBase = `/api/personnel/${person.id}`;
+    const attempts = [
+      { method: 'PATCH', url: urlBase, body: payload },
+      { method: 'PUT',   url: urlBase, body: payload },
+      { method: 'POST',  url: `${urlBase}?_method=PATCH`, body: payload },
+      { method: 'POST',  url: `${urlBase}?_method=PUT`,   body: payload },
+      { method: 'POST',  url: urlBase, body: payload, headers: { 'X-HTTP-Method-Override': 'PATCH' } },
+      { method: 'POST',  url: urlBase, body: payload, headers: { 'X-HTTP-Method-Override': 'PUT' } },
+      { method: 'POST',  url: `/api/personnel/update`, body: payload },
+    ];
+    let ok = false, lastStatus = 0, lastText = '';
+    for (const a of attempts) {
+      try {
+        const res = await fetch(a.url, {
+          method: a.method,
+          headers: { 'Content-Type': 'application/json', ...(a.headers || {}) },
+          body: JSON.stringify(a.body),
+          cache: 'no-store'
+        });
+        lastStatus = res.status;
+        lastText = await res.text().catch(()=>'');
+        if (res.ok || [200,201,202,204].includes(res.status)) { ok = true; break; }
+      } catch (e) {
+        lastText = e?.message || String(e);
+      }
+    }
+    if (!ok) {
+      alert(`Failed to save personnel changes.\nLast response (${lastStatus}): ${lastText}`);
+      return;
+    }
+    modal.style.display = 'none';
+    const refresh = window.refreshStationPanelNoCache;
+    if (typeof refresh === 'function' && (station?.id || person.station_id)) {
+      await refresh(station?.id || person.station_id);
+    }
+  };
+  modal.style.display = 'block';
+}
+
+export function editPersonnel(id, station) {
+  fetch(`/api/personnel/${id}`)
+    .then(res => res.json())
+    .then(person => {
+      openPersonnelModal(person, station);
+    });
+}
+
+export function openUnitModal(unit) {
+  const modal = document.getElementById('editUnitModal');
+  const content = document.getElementById('editUnitContent');
+  const currentName = unit?.name || '';
+  const currentPrio = Number(unit?.priority) || 1;
+  content.innerHTML = `
+    <div style="display:flex; flex-direction:column; gap:10px;">
+      <label>
+        <div>Name</div>
+        <input id="edit-unit-name" type="text" style="width:100%;" value="${currentName.replace(/"/g,'&quot;')}" />
+      </label>
+      <label>
+        <div>Priority (1-5)</div>
+        <input id="edit-unit-priority" type="number" min="1" max="5" value="${currentPrio}" />
+      </label>
+      <div style="display:flex; gap:8px; justify-content:flex-end;">
+        <button id="edit-unit-cancel" type="button">Cancel</button>
+        <button id="edit-unit-save" type="button" style="background:#0b5; color:#fff;">Save</button>
+      </div>
+    </div>`;
+  content.querySelector('#edit-unit-cancel').onclick = () => { modal.style.display = 'none'; };
+  content.querySelector('#edit-unit-save').onclick = async () => {
+    const nameEl = content.querySelector('#edit-unit-name');
+    const name = (nameEl?.value || '').trim();
+    let priority = Number(content.querySelector('#edit-unit-priority')?.value);
+    if (!Number.isFinite(priority)) priority = 1;
+    priority = Math.min(5, Math.max(1, priority));
+    const payload = { name, priority };
+    const urlBase = `/api/units/${unit.id}`;
+    const attempts = [
+      { method:'PATCH', url:urlBase, body:payload },
+      { method:'PUT', url:urlBase, body:payload },
+      { method:'POST', url:`${urlBase}?_method=PATCH`, body:payload },
+      { method:'POST', url:`${urlBase}?_method=PUT`, body:payload },
+      { method:'POST', url:urlBase, body:payload, headers:{'X-HTTP-Method-Override':'PATCH'} },
+      { method:'POST', url:urlBase, body:payload, headers:{'X-HTTP-Method-Override':'PUT'} },
+      { method:'POST', url:'/api/units/update', body:{ id:unit.id, ...payload } }
+    ];
+    let ok=false,lastStatus=0,lastText='';
+    for(const a of attempts){
+      try{
+        const res=await fetch(a.url,{method:a.method,headers:{'Content-Type':'application/json',...(a.headers||{})},body:JSON.stringify(a.body),cache:'no-store'});
+        lastStatus=res.status; lastText=await res.text().catch(()=> '');
+        if(res.ok||[200,201,202,204].includes(res.status)){ ok=true; break; }
+      }catch(e){ lastText=e?.message||String(e); }
+    }
+    if(!ok){ alert(`Failed to save unit changes.\nLast response (${lastStatus}): ${lastText}`); return; }
+    modal.style.display='none';
+    const refresh = window.refreshStationPanelNoCache;
+    if (typeof refresh === 'function') {
+      await refresh(unit.station_id);
+    }
+  };
+  modal.style.display = 'block';
+}
+
+export function editUnit(id) {
+  fetch(`/api/units/${id}`)
+    .then(res => res.json())
+    .then(unit => { openUnitModal(unit); });
+}
+
+if (typeof window !== 'undefined') {
+  Object.assign(window, { openPersonnelModal, editPersonnel, openUnitModal, editUnit });
+}


### PR DESCRIPTION
## Summary
- move edit personnel and unit dialog logic into reusable `edit-dialogs.js`
- load shared edit dialog module in both index and cad pages and add modal HTML to CAD
- use shared edit functions in CAD instead of alerts

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68b18097c0048328a4af9a2085a1e1bf