### PR TITLE
Add audio alerts for missions and dispatches

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1534,6 +1534,7 @@ async function generateMission(retry = false, excludeIndex = null) {
   try {
     const res = await fetch('/api/missions', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(missionData) });
     if (!res.ok) throw new Error(`HTTP ${res.status}`);
+    playSound('/audio/newalert.mp3');
     await fetchMissions();
   } catch (err) { console.error("Failed to create mission:", err); alert("Failed to create mission."); }
 }
@@ -2049,6 +2050,7 @@ async function openManualDispatch(mission) {
 
 async function sendUnitsToMission(mission, ids, area) {
   await Promise.all(ids.map(id => fetch('/api/mission-units',{ method:'POST', headers:{'Content-Type':'application/json'}, body: JSON.stringify({ mission_id: mission.id, unit_id: id }) })));
+  if (ids.length) playSound('/audio/dispatch.mp3');
   if (area) area.innerHTML = `<strong>Dispatched ${ids.length} unit(s) to mission #${mission.id}.</strong>`;
   const assigned = await refreshAssignedUnitsUI(mission.id);
   const reqDiv = document.getElementById('reqDynamic');

--- a/public/js/cad.js
+++ b/public/js/cad.js
@@ -1,4 +1,4 @@
-import { fetchNoCache, formatTime } from './common.js';
+import { fetchNoCache, formatTime, playSound } from './common.js';
 import { getMissions, renderMissionRow } from './missions.js';
 import { getStations, renderStationList } from './stations.js';
 import { editUnit, editPersonnel } from './edit-dialogs.js';
@@ -433,6 +433,7 @@ async function dispatchUnits(missionId, unitIds) {
       body: JSON.stringify({ mission_id: missionId, unit_id: id })
     });
   }
+  if (unitIds.length) playSound('/audio/dispatch.mp3');
 }
 
 async function openManualDispatch(mission) {
@@ -562,6 +563,7 @@ async function generateMission(retry = false, excludeIndex = null) {
   try {
     const res = await fetch('/api/missions', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(missionData) });
     if (!res.ok) throw new Error(`HTTP ${res.status}`);
+    playSound('/audio/newalert.mp3');
     await loadMissions();
   } catch (err) { console.error("Failed to create mission:", err); alert("Failed to create mission."); }
 }

--- a/public/js/common.js
+++ b/public/js/common.js
@@ -26,7 +26,19 @@ export function formatTime(seconds) {
   return `${m}:${sec.toString().padStart(2, '0')}`;
 }
 
+// Play an audio file from the given path. Errors are ignored so a
+// missing file or blocked autoplay does not break the UI.
+export function playSound(path) {
+  try {
+    const audio = new Audio(path);
+    audio.play();
+  } catch {
+    // noop
+  }
+}
+
 // Expose helpers globally for legacy scripts
 window.fetchNoCache = fetchNoCache;
 window.haversineKm = haversineKm;
 window.formatTime = formatTime;
+window.playSound = playSound;


### PR DESCRIPTION
## Summary
- add reusable `playSound` helper and expose globally
- play `newalert.mp3` when missions are created
- play `dispatch.mp3` when units are dispatched to missions

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68b1837cfa6083289b436d58da4c068e