### PR TITLE
Enable detailed unit management in CAD interface

### DIFF
--- a/public/cad.html
+++ b/public/cad.html
@@ -52,5 +52,16 @@
         <div id="editUnitContent">Loading...</div>
         <button onclick="document.getElementById('editUnitModal').style.display = 'none';">Close</button>
   </div>
+
+  <!-- Unit Detail Modal -->
+  <div id="unitDetailModal" style="
+        position: fixed; top: 20%; left: 50%; transform: translateX(-50%);
+        background: white; border: 2px solid #444; padding: 1em;
+        width: 300px; box-shadow: 0 0 10px rgba(0,0,0,0.3);
+        display: none; z-index: 10001; max-height: 80vh; overflow-y: auto;">
+        <h3>Unit Details</h3>
+        <div id="unitDetailContent">Loading...</div>
+        <button onclick="document.getElementById('unitDetailModal').style.display = 'none';">Close</button>
+  </div>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Add unit detail modal to CAD screen and wire up unit list for detailed view
- Expose training lookups in CAD to allow editing personnel training
- Show unit personnel and equipment with edit and assignment options

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68b199582c348328a4df599c5d6a32b6