### PR TITLE
Add mission generation controls to CAD

### DIFF
--- a/public/cad.html
+++ b/public/cad.html
@@ -15,7 +15,7 @@
 </head>
 <body class="cad-layout">
   <div id="cadTop">
-    <button id="returnMain">Return to Main Page</button>
+    <button id="returnMain" class="cad-action">Return to Main Page</button>
     <div id="walletDisplay">Balance: $0</div>
     <div id="cadSpeeds">
       <button class="cad-speed active" data-speed="pause">Pause</button>
@@ -23,6 +23,7 @@
       <button class="cad-speed" data-speed="medium">Medium</button>
       <button class="cad-speed" data-speed="fast">Fast</button>
     </div>
+    <button id="generateMission" class="cad-action">Generate Mission</button>
   </div>
   <div id="cadContent">
     <div id="cadMissions"></div>

--- a/public/js/cad.js
+++ b/public/js/cad.js
@@ -63,6 +63,8 @@ let cachedStations = [];
 
 async function init() {
   document.getElementById('returnMain').addEventListener('click', ()=>location.href='index.html');
+  document.getElementById('generateMission')
+          .addEventListener('click', () => generateMission());
   await updateWallet();
   await loadStations();
   await loadMissions();
@@ -676,7 +678,7 @@ async function openUnitTypeDispatch(mission) {
   });
 }
 
-async function generateMission(retry = false, excludeIndex = null) {
+export async function generateMission(retry = false, excludeIndex = null) {
   if (missionTemplates.length === 0) { alert("No mission templates loaded."); return; }
   const stations = await fetch('/api/stations').then(r => r.json()).catch(() => []);
   if (!stations.length) { alert("No stations available."); return; }

--- a/public/style.css
+++ b/public/style.css
@@ -152,3 +152,12 @@ h3 {
     background:#888;
     font-weight:bold;
 }
+
+.cad-action {
+    padding:0.5em 1em;
+    border:none;
+    background:#444;
+    color:#fff;
+    cursor:pointer;
+    margin-right:0.5em;
+}


### PR DESCRIPTION
## Summary
- add Generate Mission button to CAD top bar
- style new CAD actions to match existing buttons
- wire up mission creation handler in CAD module

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68b19b115ec883289490a07d18a2e74c