### PR TITLE
Filter unit type dispatch by mission departments

### DIFF
--- a/public/js/cad.js
+++ b/public/js/cad.js
@@ -647,9 +647,12 @@ async function openUnitTypeDispatch(mission) {
     fetchNoCache('/api/units?status=available').then(r=>r.json())
   ]);
   const stMap = new Map(stations.map(s=>[s.id,s]));
+  const missionDepts = Array.isArray(mission.departments) ? mission.departments : [];
   const groups = new Map();
   units.forEach(u=>{
     const st = stMap.get(u.station_id);
+    const dept = st?.department;
+    if (missionDepts.length && (!dept || !missionDepts.includes(dept))) return;
     const dist = st ? haversine(mission.lat, mission.lon, st.lat, st.lon) : Infinity;
     const arr = groups.get(u.type) || [];
     arr.push({ ...u, distance: dist });


### PR DESCRIPTION
## Summary
- Respect mission department restrictions when dispatching units by type.
- Skip units whose station's department is not allowed for the mission.

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68b1a2ee1f208328951b68757cc2d4ed