### PR TITLE
Add tag field to units

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1265,6 +1265,7 @@ async function showStationDetails(station) {
     <h3>Create Unit</h3>
     <select id="unit-type">${unitOptions}</select>
     <input id="unit-name" placeholder="Unit name (e.g., Ladder 1)" />
+    <input id="unit-tag" placeholder="Tag" />
     <input id="unit-priority" type="number" min="1" max="5" value="1" style="width:60px;" />
     <button id="create-unit">Create Unit</button>
     <h3>Add Personnel</h3>
@@ -1436,9 +1437,10 @@ async function showStationDetails(station) {
   document.getElementById('create-unit').addEventListener('click', async ()=>{
     const type = document.getElementById('unit-type').value;
     const name = document.getElementById('unit-name').value;
+    const tag = document.getElementById('unit-tag').value;
     const priority = Number(document.getElementById('unit-priority').value) || 1;
     if (!type || !name) return alert("Missing name or type");
-    await fetch('/api/units',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({station_id:station.id,class:station.type,type,name,priority})});
+    await fetch('/api/units',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({station_id:station.id,class:station.type,type,name,tag,priority})});
     showStationDetails(station);
   });
   document.getElementById('create-personnel').addEventListener('click', async ()=>{
@@ -1928,12 +1930,13 @@ function openUnitCreationForm(station) {
   const allowedTypes = unitTypes.filter(u => u.class === station.type);
   const unitName = prompt("Enter unit name (e.g., Engine 1):");
   if (!unitName) return;
+  const unitTag = prompt("Enter unit tag (optional):") || '';
   const typeOptions = allowedTypes.map(u => u.type).join(', ');
   const selectedType = prompt(`Choose unit type (${typeOptions}):`);
   if (!allowedTypes.find(u => u.type === selectedType)) { alert("Invalid type for this station."); return; }
   fetch("/api/units", {
     method: "POST", headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ station_id: station.id, class: station.type, type: selectedType, name: unitName })
+    body: JSON.stringify({ station_id: station.id, class: station.type, type: selectedType, name: unitName, tag: unitTag })
   }).then(res => res.json()).then(() => showStationDetails(station))
     .catch(err => { console.error("Failed to add unit:", err); alert("Error adding unit."); });
 }

--- a/public/js/cad.js
+++ b/public/js/cad.js
@@ -307,6 +307,7 @@ function openNewUnit(st) {
   html += `<h3>New Unit - ${st.name}</h3>`;
   html += `<label>Type: <select id="unitType">${options}</select></label><br>`;
   html += `<label>Name: <input id="unitName"/></label><br>`;
+  html += `<label>Tag: <input id="unitTag"/></label><br>`;
   html += `<label>Priority: <input id="unitPriority" type="number" min="1" max="5" value="1" style="width:60px;"></label><br>`;
   html += `<button id="createUnitBtn">Create</button>`;
   pane.innerHTML = html;
@@ -314,9 +315,10 @@ function openNewUnit(st) {
   document.getElementById('createUnitBtn').onclick = async ()=>{
     const type = document.getElementById('unitType').value;
     const name = document.getElementById('unitName').value.trim();
+    const tag = document.getElementById('unitTag').value.trim();
     const priority = Number(document.getElementById('unitPriority').value)||1;
     if (!type || !name) return alert('Missing name or type');
-    const res = await fetch('/api/units',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({station_id: st.id,class: st.type,type,name,priority})});
+    const res = await fetch('/api/units',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({station_id: st.id,class: st.type,type,name,tag,priority})});
     if(!res.ok){ const data = await res.json().catch(()=>({})); alert(`Failed: ${data.error || res.statusText}`); return; }
     showStation(st.id);
   };

--- a/public/js/edit-dialogs.js
+++ b/public/js/edit-dialogs.js
@@ -90,12 +90,17 @@ export function openUnitModal(unit) {
   const modal = document.getElementById('editUnitModal');
   const content = document.getElementById('editUnitContent');
   const currentName = unit?.name || '';
+  const currentTag = unit?.tag || '';
   const currentPrio = Number(unit?.priority) || 1;
   content.innerHTML = `
     <div style="display:flex; flex-direction:column; gap:10px;">
       <label>
         <div>Name</div>
         <input id="edit-unit-name" type="text" style="width:100%;" value="${currentName.replace(/"/g,'&quot;')}" />
+      </label>
+      <label>
+        <div>Tag</div>
+        <input id="edit-unit-tag" type="text" style="width:100%;" value="${currentTag.replace(/"/g,'&quot;')}" />
       </label>
       <label>
         <div>Priority (1-5)</div>
@@ -110,10 +115,11 @@ export function openUnitModal(unit) {
   content.querySelector('#edit-unit-save').onclick = async () => {
     const nameEl = content.querySelector('#edit-unit-name');
     const name = (nameEl?.value || '').trim();
+    const tag = (content.querySelector('#edit-unit-tag')?.value || '').trim();
     let priority = Number(content.querySelector('#edit-unit-priority')?.value);
     if (!Number.isFinite(priority)) priority = 1;
     priority = Math.min(5, Math.max(1, priority));
-    const payload = { name, priority };
+    const payload = { name, tag, priority };
     const urlBase = `/api/units/${unit.id}`;
     const attempts = [
       { method:'PATCH', url:urlBase, body:payload },


### PR DESCRIPTION
## Summary
- Extend units table with `tag` column and expose through API CRUD routes
- Allow creating and updating unit tags in CAD and edit dialogs
- Add tag prompts and inputs for unit creation across UI

## Testing
- `npm test` *(fails: Error: no test specified)*
- `node --check server.js`


------
https://chatgpt.com/codex/tasks/task_e_68b1ea34f4608328b060c832e4ec6915