### PR TITLE
Add flashing glow for responding unit tags

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -49,14 +49,32 @@
                         animation: flash-rwb 1s infinite;
                 }
                 @keyframes flash-rw {
-                        0%, 100% { border-color: red; }
-                        50% { border-color: white; }
+                        0%, 100% {
+                                border-color: red;
+                                box-shadow: 0 0 6px 2px red;
+                        }
+                        50% {
+                                border-color: white;
+                                box-shadow: 0 0 6px 2px white;
+                        }
                 }
                 @keyframes flash-rwb {
-                        0% { border-color: red; }
-                        33% { border-color: white; }
-                        66% { border-color: blue; }
-                        100% { border-color: red; }
+                        0% {
+                                border-color: red;
+                                box-shadow: 0 0 6px 2px red;
+                        }
+                        33% {
+                                border-color: white;
+                                box-shadow: 0 0 6px 2px white;
+                        }
+                        66% {
+                                border-color: blue;
+                                box-shadow: 0 0 6px 2px blue;
+                        }
+                        100% {
+                                border-color: red;
+                                box-shadow: 0 0 6px 2px red;
+                        }
                 }
         </style>
 </head>


### PR DESCRIPTION
## Summary
- Animate unit tag border and glow to highlight responding units

## Testing
- `npm test` (fails: Error: no test specified)

------
https://chatgpt.com/codex/tasks/task_e_68b1f05a1e1c83288b3d11363adfe7e1