### PR TITLE
Allow Leaflet panes to overflow

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -42,6 +42,7 @@
                 .unit-tag-icon.police { background: blue; }
                 .unit-tag-icon.ambulance { background: green; }
                 .leaflet-marker-icon { overflow: visible !important; }
+                .leaflet-pane, .leaflet-marker-pane { overflow: visible !important; }
                 .unit-tag-icon.responding.fire,
                 .unit-tag-icon.responding.ambulance {
                         animation: flash-rw 1s infinite;


### PR DESCRIPTION
## Summary
- Ensure Leaflet panes and markers allow overflow so unit glow isn't clipped

## Testing
- `npm test` *(fails: Error: no test specified)*
- `node server.js` *(fails: SQLITE_ERROR: no such column: responding)*

------
https://chatgpt.com/codex/tasks/task_e_68b1f67c6b8c8328893bf0843afd41b4