### PR TITLE
Fix mission resolve timer detection

### DIFF
--- a/server.js
+++ b/server.js
@@ -2067,7 +2067,8 @@ setInterval(() => {
           (e2, units) => {
             if (e2 || !units) return;
             const allMet = missionRequirementsMet(m, units);
-            const hasTimer = missionClocks.has(m.id) || m.resolve_at != null;
+            const dbEnd = m.resolve_at != null ? Number(m.resolve_at) : null;
+            const hasTimer = missionClocks.has(m.id) || (dbEnd && dbEnd > Date.now());
             if (allMet && !hasTimer) beginMissionClock(m.id);
             else if (!allMet && hasTimer) clearMissionClock(m.id);
           }


### PR DESCRIPTION
## Summary
- Avoid treating past `resolve_at` timestamps as active mission timers
- Start mission timer only when requirements met and no active timer

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68b3a9aa8b5483288eae7c28b7857649