### PR TITLE
Fix mission timers clearing when requirements met

### DIFF
--- a/server.js
+++ b/server.js
@@ -2056,7 +2056,12 @@ setInterval(() => {
       if (err || !missions) return;
       missions.forEach(m => {
         db.all(
-          `SELECT u.* FROM mission_units mu JOIN units u ON u.id = mu.unit_id WHERE mu.mission_id=?`,
+          `SELECT u.*, COALESCE(json_group_array(json_object('id', p.id, 'name', p.name, 'training', p.training)), '[]') AS personnel
+           FROM mission_units mu
+           JOIN units u ON u.id = mu.unit_id
+           LEFT JOIN personnel p ON p.unit_id = u.id
+           WHERE mu.mission_id=?
+           GROUP BY u.id`,
           [m.id],
           (e2, units) => {
             if (e2 || !units) return;


### PR DESCRIPTION
## Summary
- include assigned personnel in periodic mission checks so training requirements are evaluated correctly

## Testing
- `npm test` *(fails: Error: no test specified)*
- `curl -s -X POST http://localhost:911/api/missions/242/timer` then waited and verified `/api/missions/242` retained `resolve_at`


------
https://chatgpt.com/codex/tasks/task_e_68b48340fb208328b6fec29b84f64384