### PR TITLE
Allow manual dispatch across departments

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -2150,8 +2150,8 @@ async function openManualDispatch(mission) {
   }
 }
 
-async function sendUnitsToMission(mission, ids, area) {
-  await Promise.all(ids.map(id => fetch('/api/mission-units',{ method:'POST', headers:{'Content-Type':'application/json'}, body: JSON.stringify({ mission_id: mission.id, unit_id: id }) })));
+  async function sendUnitsToMission(mission, ids, area, force=false) {
+    await Promise.all(ids.map(id => fetch('/api/mission-units',{ method:'POST', headers:{'Content-Type':'application/json'}, body: JSON.stringify({ mission_id: mission.id, unit_id: id, ...(force ? { force: true } : {}) }) })));
   if (ids.length) playSound('/audio/dispatch.mp3');
   if (area) area.innerHTML = `<strong>Dispatched ${ids.length} unit(s) to mission #${mission.id}.</strong>`;
   const assigned = await refreshAssignedUnitsUI(mission.id);
@@ -2223,7 +2223,7 @@ async function dispatchSelectedUnits(missionId) {
     const missions = await (await fetch('/api/missions')).json();
     const mission = missions.find(m=>m.id===missionId);
     if (!mission) { alert('Mission not found.'); return; }
-    await sendUnitsToMission(mission, ids, area);
+    await sendUnitsToMission(mission, ids, area, true);
     openManualDispatch({ id: missionId, lat: mission.lat, lon: mission.lon });
   } catch (e) {
     console.error(e);
@@ -2261,7 +2261,7 @@ async function openUnitTypeDispatch(mission) {
         const list = groups.get(type) || [];
         if (!list.length) { alert('No available units'); return; }
         const unit = list.shift();
-        await sendUnitsToMission(mission, [unit.id]);
+        await sendUnitsToMission(mission, [unit.id], undefined, true);
         openUnitTypeDispatch(mission);
       });
     });

--- a/public/js/cad.js
+++ b/public/js/cad.js
@@ -688,12 +688,12 @@ async function runCardDispatch(mission) {
   }
 }
 
-async function dispatchUnits(mission, units) {
+async function dispatchUnits(mission, units, force=false) {
   for (const u of units) {
     await fetch('/api/mission-units', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ mission_id: mission.id, unit_id: u.id })
+      body: JSON.stringify({ mission_id: mission.id, unit_id: u.id, ...(force ? { force: true } : {}) })
     });
 
     try {
@@ -778,7 +778,7 @@ async function openManualDispatch(mission) {
   document.getElementById('dispatchUnits').onclick = async ()=>{
     const ids = Array.from(unitsPane.querySelectorAll('input[type=checkbox]:checked')).map(c=>Number(c.value));
     const selectedUnits = ids.map(id => available.find(u => u.id === id)).filter(Boolean);
-    await dispatchUnits(mission, selectedUnits);
+    await dispatchUnits(mission, selectedUnits, true);
     unitsPane.classList.add('hidden');
     await loadMissions();
     await openMission(mission.id);
@@ -817,7 +817,7 @@ async function openUnitTypeDispatch(mission) {
       const list = groups.get(type) || [];
       if (!list.length) { alert('No available units'); return; }
       const unit = list.shift();
-      await dispatchUnits(mission, [unit]);
+      await dispatchUnits(mission, [unit], true);
       await loadMissions();
       await openMission(mission.id);
       openUnitTypeDispatch(mission);

--- a/server.js
+++ b/server.js
@@ -1769,7 +1769,7 @@ app.put('/api/run-cards/:name', express.json(), (req, res) => {
    (with global busy guard)
    ========================= */
 app.post('/api/mission-units', (req, res) => {
-  const { mission_id, unit_id } = req.body || {};
+  const { mission_id, unit_id, force } = req.body || {};
   if (!mission_id || !unit_id) return res.status(400).json({ error: 'mission_id and unit_id are required' });
 
   // Guard: prevent double-dispatch across all missions and fetch department
@@ -1791,7 +1791,7 @@ app.post('/api/mission-units', (req, res) => {
           if (!m) return res.status(404).json({ error: 'mission not found' });
 
           const allowed = parseArrayField(m.departments);
-          if (allowed.length && !allowed.includes(unitRow.department)) {
+          if (!force && allowed.length && !allowed.includes(unitRow.department)) {
             return res.status(403).json({ error: 'department not allowed' });
           }
 


### PR DESCRIPTION
## Summary
- Allow API mission-unit assignments to skip department filtering when `force` is true
- Send `force: true` from manual dispatch flows so cross-department assignments succeed
- Keep algorithmic dispatches unchanged to preserve department restrictions

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68b48885e6888328a8a9b7bc11796b8a