### PR TITLE
Sort unit types for grouped dropdowns

### DIFF
--- a/unitTypes.js
+++ b/unitTypes.js
@@ -19,6 +19,7 @@ const unitTypes = [
   { class: "police", type: "Special Operations", capacity: 4, equipmentSlots: 4, attributes: [], cost: 20000 },
   { class: "police", type: "SWAT Van",        capacity: 6, equipmentSlots: 4, attributes: ["armor","SWAT"], cost: 30000 }
 ];
+unitTypes.sort((a,b) => a.class.localeCompare(b.class) || a.type.localeCompare(b.type));
 if (typeof module !== 'undefined' && typeof module.exports !== 'undefined') {
   module.exports = unitTypes;
 }


### PR DESCRIPTION
## Summary
- sort `unitTypes` by class then type so dropdowns appear grouped and alphabetized

## Testing
- `node -e "const unitTypes=require('./unitTypes'); console.log(unitTypes.map(u=>u.class+'-'+u.type).join('\n'));"`
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68b48d7ef814832886019aca7d18c941