### PR TITLE
Fix layout overflow to remove page scroll on index and CAD pages

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -11,10 +11,11 @@
         <script src="https://cdn.jsdelivr.net/npm/@turf/turf@6/turf.min.js"></script>
         <script type="module" src="js/common.js"></script>
         <script type="module" src="js/edit-dialogs.js"></script>
-	<style>
-		body { margin: 0; display: flex; height: 100vh; font-family: sans-serif; }
-		#sidebar { max-width: 30%; width: 100%; overflow-y: auto; padding: 10px; box-sizing: border-box; }
-		#map { flex: 1; }
+        <style>
+                html, body { height: 100%; margin: 0; overflow: hidden; }
+                body { display: flex; height: 100vh; font-family: sans-serif; }
+                #sidebar { max-width: 30%; width: 100%; overflow-y: auto; padding: 10px; box-sizing: border-box; }
+                #map { flex: 1; }
 		.mission { border-bottom: 1px solid #ccc; margin-bottom: 1em; padding-bottom: 0.5em; }
                 .tab-button { padding: 0.5em 1em; border: none; background: #ddd; cursor: pointer; }
                 .tab-button.active { background: #aaa; font-weight: bold; }

--- a/public/style.css
+++ b/public/style.css
@@ -1,4 +1,10 @@
-body{  
+html, body {
+    height:100%;
+    margin:0;
+    overflow:hidden;
+}
+
+body{
     font-family:Georgia, Arial, Helvetica, Sans-serif,serif;
     font-size:15px;
     color:#000;
@@ -73,7 +79,7 @@ h3 {
     display:grid;
     grid-template-rows:1fr 1fr;
     grid-template-columns:1fr 1fr;
-    height:100%;
+    min-height:0;
 }
 
 #cadMissions {


### PR DESCRIPTION
## Summary
- prevent body overflow and margin by applying `html, body` rules and overflow hidden
- adjust CAD content grid to flex remaining space without page scroll
- ensure main index layout uses the same viewport-fitting rule

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68b490f81f088328a98a70e8ff3e2f61