### PR TITLE
Rename police special ops and adjust training names

### DIFF
--- a/trainings.js
+++ b/trainings.js
@@ -23,7 +23,7 @@ const trainingsByClass = {
     { name: "EMR", cost: 400 },
     { name: "paramedic", cost: 800 },
     { name: "critical care", cost: 1200 },
-    { name: "supervisor", cost: 900 },
+    { name: "team lead", cost: 900 },
     { name: "incident command", cost: 1000 }
   ]
 };

--- a/unitTypes.js
+++ b/unitTypes.js
@@ -16,7 +16,7 @@ const unitTypes = [
 
   { class: "police", type: "Patrol Car",      capacity: 2, equipmentSlots: 1, attributes: ["prisonerTransport"], cost: 9000  },
   { class: "police", type: "Unmarked Car",    capacity: 2, equipmentSlots: 1, attributes: [], cost: 9500  },
-  { class: "police", type: "Special Operations", capacity: 4, equipmentSlots: 4, attributes: [], cost: 20000 },
+  { class: "police", type: "Special Services", capacity: 4, equipmentSlots: 4, attributes: [], cost: 20000 },
   { class: "police", type: "SWAT Van",        capacity: 6, equipmentSlots: 4, attributes: ["armor","SWAT"], cost: 30000 }
 ];
 unitTypes.sort((a,b) => a.class.localeCompare(b.class) || a.type.localeCompare(b.type));


### PR DESCRIPTION
## Summary
- Rename police "Special Operations" unit to "Special Services" to avoid duplicate with fire.
- Rename ambulance "supervisor" training to "team lead" while retaining police "supervisor" training.

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68b49712ec4c8328b8a6520d378151f0