### PR TITLE
feat: enable scrolling for admin mission table

### DIFF
--- a/public/admin.html
+++ b/public/admin.html
@@ -4,6 +4,12 @@
   <meta charset="UTF-8">
   <title>Mission Admin</title>
   <link rel="stylesheet" href="style.css">
+  <style>
+    #mission-table-container {
+      max-height: 80vh;
+      overflow-y: auto;
+    }
+  </style>
 </head>
 <script src="config/unitTypes.js"></script>
 <script src="config/trainings.js"></script>
@@ -18,6 +24,7 @@
   <div id="runcard-form-container" style="display: none;"></div>
 
   <h2>Existing Missions</h2>
+  <div id="mission-table-container">
   <table id="mission-table" border="1">
     <thead>
       <tr>
@@ -40,5 +47,6 @@
     </thead>
     <tbody></tbody>
   </table>
+  </div>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Add scrollable container around mission table in `admin.html` so long lists remain accessible.

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68b4982b537083289c4b1d7bef67e973