### PR TITLE
Expand OSM POI tags for mission generation

### DIFF
--- a/osmPoiTypes.js
+++ b/osmPoiTypes.js
@@ -28,5 +28,18 @@ const OSM_POI_TYPES = [
   "supermarket",
   "taxi",
   "theatre",
-  "train_station"
+  "train_station",
+  "building=house",
+  "building=apartments",
+  "tourism=hotel",
+  "leisure=swimming_pool",
+  "amenity=nursing_home",
+  "amenity=clinic",
+  "aeroway=hangar",
+  "landuse=landfill",
+  "shop=mall",
+  "building=warehouse",
+  "man_made=works",
+  "building=office",
+  "office=government"
 ];

--- a/public/index.html
+++ b/public/index.html
@@ -810,7 +810,8 @@ async function generateMissionAtPOI(poi) {
   const mission = await res.json();
   const { name, required_units } = mission;
   document.getElementById("cadTitle").textContent = name;
-  document.getElementById("cadType").textContent = `POI: ${poi.tags.amenity || poi.tags.name}`;
+  const tagVal = poi.tags.amenity || poi.tags.building || poi.tags.leisure || poi.tags.tourism || poi.tags.shop || poi.tags.aeroway || poi.tags.landuse || poi.tags.office || poi.tags.man_made || poi.tags.name;
+  document.getElementById("cadType").textContent = `POI: ${tagVal}`;
   const formatReq = r => {
     const types = Array.isArray(r.types) ? r.types : [r.type];
     const typeStr = types.join(' or ');
@@ -1570,7 +1571,14 @@ async function generateMission(retry = false, excludeIndex = null) {
     try {
       const pois = await fetch(`/api/pois?lat=${st.lat}&lon=${st.lon}&radius=${radius}`)
         .then(r => r.json()).catch(() => []);
-      const matches = pois.filter(p => p.tags && p.tags.amenity === template.trigger_filter);
+      const matches = pois.filter(p => {
+        if (!p.tags) return false;
+        if ((template.trigger_filter || "").includes("=")) {
+          const [key, val] = template.trigger_filter.split("=");
+          return p.tags[key] === val;
+        }
+        return p.tags.amenity === template.trigger_filter;
+      });
       if (matches.length) {
         const poi = matches[Math.floor(Math.random() * matches.length)];
         lat = poi.lat; lon = poi.lon;

--- a/public/js/cad.js
+++ b/public/js/cad.js
@@ -867,7 +867,14 @@ export async function generateMission(retry = false, excludeIndex = null) {
     try {
       const pois = await fetch(`/api/pois?lat=${st.lat}&lon=${st.lon}&radius=${radius}`)
         .then(r => r.json()).catch(() => []);
-      const matches = pois.filter(p => p.tags && p.tags.amenity === template.trigger_filter);
+      const matches = pois.filter(p => {
+        if (!p.tags) return false;
+        if ((template.trigger_filter || "").includes("=")) {
+          const [key, val] = template.trigger_filter.split("=");
+          return p.tags[key] === val;
+        }
+        return p.tags.amenity === template.trigger_filter;
+      });
       if (matches.length) {
         const poi = matches[Math.floor(Math.random() * matches.length)];
         lat = poi.lat; lon = poi.lon;

--- a/server.js
+++ b/server.js
@@ -643,7 +643,7 @@ app.get('/api/pois', async (req, res) => {
   try {
     const response = await axios.get(`https://overpass-api.de/api/interpreter`, {
       params: {
-        data: `[out:json];node(around:${radius},${lat},${lon})["amenity"];out;`
+        data: `[out:json];(node(around:${radius},${lat},${lon})["amenity"];node(around:${radius},${lat},${lon})["building"];node(around:${radius},${lat},${lon})["leisure"];node(around:${radius},${lat},${lon})["tourism"];node(around:${radius},${lat},${lon})["shop"];node(around:${radius},${lat},${lon})["aeroway"];node(around:${radius},${lat},${lon})["landuse"];node(around:${radius},${lat},${lon})["office"];node(around:${radius},${lat},${lon})["man_made"];);out;`
       }
     });
     res.json(response.data.elements);


### PR DESCRIPTION
## Summary
- add OSM tag-based POIs like houses, apartments, hotels, pools, and more
- support `key=value` POI filters in mission generation and display
- broaden Overpass queries to fetch additional tag categories

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68b4d265485083289f55d78fdc4bef6f