### PR TITLE
Add status formatter and apply across UI

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -378,7 +378,9 @@ function setUnitEta(unitId, elem, startedAt, totalDuration){
   function update(){
     const elapsed = (Date.now() - new Date(startedAt).getTime())/1000;
     const remaining = Math.max(0, (totalDuration||0) - elapsed);
-    elem.textContent = `enroute (${formatEta(remaining)})`;
+    const unit = _unitById.get(unitId);
+    const statusText = formatStatus('enroute', unit?.responding);
+    elem.textContent = `${statusText} (${formatEta(remaining)})`;
     if (remaining <= 0) clearUnitEta(unitId);
   }
   update();
@@ -1007,7 +1009,7 @@ async function refreshAssignedUnitsUI(missionId) {
       <ul style="list-style:none; padding-left:0;">
         ${assigned.map(u => `
           <li style="display:flex; align-items:center; gap:6px; margin:4px 0;">
-            <span class="unit-link" data-unitid="${u.id}" style="cursor:pointer; color:blue;">${u.name}</span> (${u.type}) — <span id="unit-status-${u.id}">${u.status || 'enroute'}</span>
+            <span class="unit-link" data-unitid="${u.id}" style="cursor:pointer; color:blue;">${u.name}</span> (${u.type}) — <span id="unit-status-${u.id}">${formatStatus(u.status || 'enroute', u.responding)}</span>
             <button data-unitid="${u.id}" data-missionid="${missionId}" class="clear-unit-btn">Clear</button>
           </li>
         `).join('')}
@@ -1337,7 +1339,7 @@ async function showStationDetails(station) {
     <ul id="unit-list">
       ${units.map(u=>`
         <li>
-          <strong style="cursor:pointer; color:blue;" onclick="showUnitDetails(${u.id})">${u.name}</strong> (${u.type}) [P${u.priority}] - ${u.status}
+          <strong style="cursor:pointer; color:blue;" onclick="showUnitDetails(${u.id})">${u.name}</strong> (${u.type}) [P${u.priority}] - ${formatStatus(u.status, u.responding)}
           <button onclick="openAssignModal(${u.id}, ${station.id})">Assign</button>
           ${u.status !== 'available' ? `<button onclick="cancelUnit(${u.id}, ${station.id})">Cancel</button>` : ''}
           <button class="edit-unit-btn" data-unitid="${u.id}">Edit</button>

--- a/public/js/cad.js
+++ b/public/js/cad.js
@@ -1,4 +1,4 @@
-import { fetchNoCache, formatTime, playSound } from './common.js';
+import { fetchNoCache, formatTime, playSound, formatStatus } from './common.js';
 import { getMissions, renderMissionRow } from './missions.js';
 import { getStations, renderStationList } from './stations.js';
 import { editUnit, editPersonnel } from './edit-dialogs.js';
@@ -510,7 +510,8 @@ async function openMission(id) {
         const sec = Math.max(0, (u.eta - Date.now()) / 1000);
         etaText = ` (${formatTime(sec)})`;
       }
-      return `<li>${u.name} - ${u.status}${etaText} <button class="cancel-unit" data-unit="${u.id}">Cancel</button></li>`;
+      const statusText = formatStatus(u.status, u.responding);
+      return `<li>${u.name} - ${statusText}${etaText} <button class="cancel-unit" data-unit="${u.id}">Cancel</button></li>`;
     }).join('') + '</ul></div>';
   }
   pane.innerHTML = `<div class="cad-detail-header">

--- a/public/js/common.js
+++ b/public/js/common.js
@@ -26,6 +26,20 @@ export function formatTime(seconds) {
   return `${m}:${sec.toString().padStart(2, '0')}`;
 }
 
+// Map internal unit statuses to human readable status codes
+export function formatStatus(status, responding = false) {
+  switch (status) {
+    case 'available':
+      return 'Status 8';
+    case 'enroute':
+      return responding ? 'Status 11' : 'Status 10';
+    case 'on_scene':
+      return 'Status 12';
+    default:
+      return status;
+  }
+}
+
 // Play an audio file from the given path. Errors are ignored so a
 // missing file or blocked autoplay does not break the UI.
 export function playSound(path) {
@@ -41,4 +55,5 @@ export function playSound(path) {
 window.fetchNoCache = fetchNoCache;
 window.haversineKm = haversineKm;
 window.formatTime = formatTime;
+window.formatStatus = formatStatus;
 window.playSound = playSound;


### PR DESCRIPTION
## Summary
- add `formatStatus` helper for mapping unit statuses to status codes
- show formatted statuses in CAD mission details and index page unit lists
- display formatted status text when tracking unit ETA

## Testing
- `npm test` *(fails: Error: no test specified)*
- `node server.js` *(server started at http://localhost:911 and was terminated)*

------
https://chatgpt.com/codex/tasks/task_e_68b5000d8ba483289aa09e55defa0dfc