### PR TITLE
Add map under CAD call details and style mission warnings

### DIFF
--- a/public/cad.html
+++ b/public/cad.html
@@ -3,6 +3,8 @@
 <head>
   <meta charset="UTF-8" />
   <title>CAD Interface</title>
+  <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" />
+  <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
   <link rel="stylesheet" href="style.css" />
   <script src="/config/unitTypes.js"></script>
   <script src="/config/trainings.js"></script>
@@ -27,6 +29,7 @@
   </div>
   <div id="cadContent">
     <div id="cadMissions"></div>
+    <div id="cadMap"></div>
     <div id="cadDetail" class="hidden"></div>
     <div id="cadStations"></div>
     <div id="cadUnits" class="hidden"></div>

--- a/public/js/cad.js
+++ b/public/js/cad.js
@@ -73,11 +73,33 @@ async function fetchRouteOSRM(from, to) {
 
 let cachedMissions = [];
 let cachedStations = [];
+let map;
+let mapMarker;
+
+function initMap() {
+  map = L.map('cadMap').setView([37.8, -96], 4);
+  L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+    maxZoom: 19,
+    attribution: '© OpenStreetMap'
+  }).addTo(map);
+}
+
+function showMissionOnMap(mission) {
+  if (!map) return;
+  if (mapMarker) {
+    map.removeLayer(mapMarker);
+  }
+  if (Number.isFinite(mission.lat) && Number.isFinite(mission.lon)) {
+    map.setView([mission.lat, mission.lon], 13);
+    mapMarker = L.marker([mission.lat, mission.lon]).addTo(map);
+  }
+}
 
 async function init() {
   document.getElementById('returnMain').addEventListener('click', ()=>location.href='index.html');
   document.getElementById('generateMission')
           .addEventListener('click', () => generateMission());
+  initMap();
   await updateWallet();
   await loadStations();
   await loadMissions();
@@ -454,6 +476,8 @@ async function showUnitDetail(unitId) {
 
 async function openMission(id) {
   const mission = cachedMissions.find(m=>String(m.id)===String(id));
+  if (!mission) return;
+  showMissionOnMap(mission);
   const pane = document.getElementById('cadDetail');
   const assigned = await fetchNoCache(`/api/missions/${id}/units`).then(r=>r.json()).catch(()=>[]);
   let time = '';

--- a/public/js/missions.js
+++ b/public/js/missions.js
@@ -29,7 +29,8 @@ export function renderMissionRow(mission) {
     const sec = Math.max(0, (mission.resolve_at - Date.now())/1000);
     time = ` - ${formatTime(sec)}`;
   }
-  return `<div class="cad-mission" data-id="${mission.id}"><img src="${icon}" class="cad-icon"/> ${mission.type || 'Mission'}${time}<div class="cad-address">${mission.address || ''}</div></div>`;
+  const cls = `cad-mission warning${lvl}`;
+  return `<div class="${cls}" data-id="${mission.id}"><img src="${icon}" class="cad-icon"/> ${mission.type || 'Mission'}${time}<div class="cad-address">${mission.address || ''}</div></div>`;
 }
 
 // Expose globally

--- a/public/style.css
+++ b/public/style.css
@@ -80,6 +80,7 @@ h3 {
     grid-template-rows:1fr 1fr;
     grid-template-columns:1fr 1fr;
     min-height:0;
+    position:relative;
 }
 
 #cadMissions {
@@ -90,6 +91,14 @@ h3 {
     background:#2a2a2a;
 }
 
+#cadMap {
+    grid-row:2;
+    grid-column:1;
+    width:100%;
+    height:100%;
+    z-index:1;
+}
+
 #cadDetail {
     grid-row:2;
     grid-column:1;
@@ -97,6 +106,10 @@ h3 {
     color:#fff;
     overflow-y:auto;
     padding:8px;
+    z-index:2;
+    position:relative;
+    width:100%;
+    height:100%;
 }
 
 #cadStations {
@@ -130,6 +143,14 @@ h3 {
 
 .cad-mission:hover {
     background:#3a3a3a;
+}
+
+.cad-mission.warning1 {
+    font-weight:bold;
+}
+
+.cad-mission.warning2 {
+    font-style:italic;
 }
 
 .cad-icon {


### PR DESCRIPTION
## Summary
- Embed Leaflet map in CAD view and center it on selected mission
- Overlay mission detail pane above map
- Style mission list by warning level: warning1 bold, warning2 italic

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68b77148b7a8832892b31f9340fd2b5c