### PR TITLE
refactor: modularize core routes

### DIFF
--- a/controllers/missionsController.js
+++ b/controllers/missionsController.js
@@ -1,0 +1,161 @@
+const db = require('../db');
+const { parseArrayField, reverseGeocode, pointInPolygon } = require('../utils');
+const { beginMissionClock, clearMissionClock, missionClocks } = require('../services/missionTimers');
+
+// GET /api/missions
+async function getMissions(req, res) {
+  const sql = `
+    SELECT m.,
+           SUM(CASE WHEN u.status = 'enroute' THEN 1 ELSE 0 END) AS responding_count,
+           SUM(CASE WHEN u.status IN ('enroute','on_scene') THEN 1 ELSE 0 END) AS assigned_count
+    FROM missions m
+    LEFT JOIN mission_units mu ON mu.mission_id = m.id
+    LEFT JOIN units u ON u.id = mu.unit_id
+    GROUP BY m.id
+  `;
+  db.all(sql, (err, rows) => {
+    if (err) return res.status(500).json({ error: err.message });
+    const parsed = rows.map(m => ({
+      ...m,
+      departments: parseArrayField(m.departments),
+      required_units: parseArrayField(m.required_units),
+      required_training: parseArrayField(m.required_training),
+      equipment_required: parseArrayField(m.equipment_required),
+      patients: parseArrayField(m.patients),
+      prisoners: parseArrayField(m.prisoners),
+      modifiers: parseArrayField(m.modifiers),
+      penalty_options: parseArrayField(m.penalty_options),
+      penalties: parseArrayField(m.penalties),
+      timing: typeof m.timing === 'number' ? m.timing : 10,
+      resolve_at: m.resolve_at != null ? Number(m.resolve_at) : null,
+      non_emergency: m.non_emergency === 1 || m.non_emergency === true,
+      responding_count: Number(m.responding_count) || 0,
+      assigned_count: Number(m.assigned_count) || 0
+    }));
+    res.json(parsed);
+  });
+}
+
+// POST /api/missions
+async function createMission(req, res) {
+  const {
+    type, lat, lon,
+    required_units = [], required_training = [],
+    equipment_required = [], patients = [], prisoners = [], modifiers = [],
+    penalty_options = [], penalties = [],
+    timing = 10,
+    non_emergency = null
+  } = req.body;
+
+  const address = await reverseGeocode(lat, lon);
+
+  db.all('SELECT * FROM response_zones', (err, zones) => {
+    if (err) return res.status(500).json({ error: err.message });
+
+    const departmentSet = new Set();
+    zones.forEach(z => {
+      try {
+        const poly = JSON.parse(z.polygon || '{}');
+        if (pointInPolygon(lat, lon, poly)) {
+          parseArrayField(z.departments).forEach(d => departmentSet.add(d));
+        }
+      } catch {}
+    });
+    const departments = Array.from(departmentSet);
+
+    db.run(`
+      INSERT INTO missions
+      (type, lat, lon, address, departments, required_units, required_training, equipment_required, patients, prisoners, modifiers, penalty_options, penalties, status, timing, non_emergency)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    `,
+    [
+      type, lat, lon, address,
+      JSON.stringify(departments),
+      JSON.stringify(required_units),
+      JSON.stringify(required_training),
+      JSON.stringify(equipment_required),
+      JSON.stringify(patients),
+      JSON.stringify(prisoners),
+      JSON.stringify(modifiers),
+      JSON.stringify(penalty_options),
+      JSON.stringify(penalties),
+      'active',
+      timing,
+      non_emergency ? 1 : null
+    ],
+    function (err2) {
+      if (err2) return res.status(500).json({ error: err2.message });
+      res.json({
+        id: this.lastID,
+        type, lat, lon, address,
+        departments,
+        required_units, required_training, equipment_required, patients, prisoners, modifiers,
+        penalty_options, penalties,
+        status: 'active',
+        timing
+      });
+    });
+  });
+}
+
+// PUT /api/missions/:id
+function updateMission(req, res) {
+  const missionId = parseInt(req.params.id, 10);
+  db.run(`UPDATE missions SET status='resolved' WHERE id=?`, [missionId], function (err) {
+    if (err) return res.status(500).json({ error: err.message });
+    res.json({ id: missionId, status: 'resolved' });
+  });
+}
+
+// DELETE /api/missions
+function deleteMissions(req, res) {
+  db.run('DELETE FROM missions', err => {
+    if (err) return res.status(500).json({ error: err.message });
+    res.sendStatus(200);
+  });
+}
+
+// Minimal timer endpoints using service
+function startTimer(req, res) {
+  const missionId = parseInt(req.params.id, 10);
+  if (!missionId) return res.status(400).json({ error: 'invalid id' });
+  beginMissionClock(missionId, end => {
+    if (!end) return res.status(404).json({ error: 'mission not found' });
+    res.json({ resolve_at: end });
+  });
+}
+
+function modifyTimer(req, res) {
+  const missionId = parseInt(req.params.id, 10);
+  if (!missionId) return res.status(400).json({ error: 'invalid id' });
+  const reduction = Math.max(-100, Math.min(100, Number(req.body?.reduction) || 0));
+  const clk = missionClocks.get(missionId);
+  if (!clk) return res.status(404).json({ error: 'timer not running' });
+  const now = Date.now();
+  const elapsed = now - clk.startedAt;
+  const remaining = Math.max(0, clk.baseDuration - elapsed);
+  const newRemaining = remaining * (1 - reduction / 100);
+  const endAt = now + newRemaining;
+  clk.endAt = endAt;
+  db.run('UPDATE missions SET resolve_at=? WHERE id=?', [endAt, missionId], err => {
+    if (err) return res.status(500).json({ error: err.message });
+    res.json({ resolve_at: endAt });
+  });
+}
+
+function clearTimer(req, res) {
+  const missionId = parseInt(req.params.id, 10);
+  if (!missionId) return res.status(400).json({ error: 'invalid id' });
+  clearMissionClock(missionId);
+  res.json({ ok: true });
+}
+
+module.exports = {
+  getMissions,
+  createMission,
+  updateMission,
+  deleteMissions,
+  startTimer,
+  modifyTimer,
+  clearTimer,
+};

--- a/controllers/stationsController.js
+++ b/controllers/stationsController.js
@@ -1,0 +1,65 @@
+const db = require('../db');
+
+// GET /api/stations
+function getStations(req, res) {
+  db.all('SELECT * FROM stations', (err, rows) => {
+    if (err) return res.status(500).send('Error reading stations');
+    const parsed = rows.map(r => {
+      let equipment; try { equipment = JSON.parse(r.equipment || '[]'); } catch { equipment = []; }
+      return { ...r, equipment };
+    });
+    res.json(parsed);
+  });
+}
+
+// GET /api/stations/:id
+function getStation(req, res) {
+  const id = Number(req.params.id);
+  if (!id) return res.status(400).json({ error: 'Invalid station id' });
+  db.get('SELECT * FROM stations WHERE id=?', [id], (err, row) => {
+    if (err) return res.status(500).json({ error: err.message });
+    if (!row) return res.status(404).json({ error: 'Station not found' });
+    let equipment; try { equipment = JSON.parse(row.equipment || '[]'); } catch { equipment = []; }
+    res.json({ ...row, equipment });
+  });
+}
+
+// POST /api/stations
+function createStation(req, res) {
+  const { name, type, lat, lon, department } = req.body || {};
+  db.run(
+    'INSERT INTO stations (name, type, lat, lon, department) VALUES (?, ?, ?, ?, ?)',
+    [name, type, lat, lon, department],
+    function (err) {
+      if (err) return res.status(500).json({ error: err.message });
+      res.json({ id: this.lastID, name, type, lat, lon, department });
+    }
+  );
+}
+
+// PATCH /api/stations/:id/bays
+function patchBays(req, res) {
+  const stationId = Number(req.params.id);
+  const add = Math.max(0, Number(req.body?.add || 0));
+  if (!stationId || !add) return res.status(400).json({ error: 'Invalid station id/add' });
+  db.run('UPDATE stations SET bay_count = COALESCE(bay_count,0) + ? WHERE id=?', [add, stationId], function (err) {
+    if (err) return res.status(500).json({ error: err.message });
+    res.json({ success: true, station_id: stationId, added: add });
+  });
+}
+
+// DELETE /api/stations
+function deleteStations(req, res) {
+  db.run('DELETE FROM stations', err => {
+    if (err) return res.status(500).send('Error deleting stations.');
+    res.send('All stations deleted.');
+  });
+}
+
+module.exports = {
+  getStations,
+  getStation,
+  createStation,
+  patchBays,
+  deleteStations,
+};

--- a/controllers/unitsController.js
+++ b/controllers/unitsController.js
@@ -1,0 +1,140 @@
+const db = require('../db');
+const { parseArrayField } = require('../utils');
+
+// GET /api/units
+function getUnits(req, res) {
+  const { station_id, status } = req.query;
+  const params = [];
+  let sql = 'SELECT * FROM units';
+  const where = [];
+  if (station_id) { where.push('station_id = ?'); params.push(station_id); }
+  if (status) { where.push('status = ?'); params.push(status); }
+  if (where.length) sql += ' WHERE ' + where.join(' AND ');
+
+  db.all(sql, params, (err, rows) => {
+    if (err) return res.status(500).json({ error: err.message });
+    const parsed = rows.map(u => ({
+      ...u,
+      priority: Number(u.priority) || 1,
+      patrol: u.patrol === 1 || u.patrol === true,
+      responding: u.responding === 1 || u.responding === true,
+      equipment: parseArrayField(u.equipment),
+    }));
+    res.json(parsed);
+  });
+}
+
+// GET /api/units/:id
+function getUnit(req, res) {
+  const id = Number(req.params.id);
+  if (!id) return res.status(400).json({ error: 'Invalid unit id' });
+  db.get('SELECT * FROM units WHERE id=?', [id], (err, row) => {
+    if (err) return res.status(500).json({ error: err.message });
+    if (!row) return res.status(404).json({ error: 'Not found' });
+    const parsed = {
+      ...row,
+      priority: Number(row.priority) || 1,
+      patrol: row.patrol === 1 || row.patrol === true,
+      responding: row.responding === 1 || row.responding === true,
+      equipment: parseArrayField(row.equipment),
+    };
+    res.json(parsed);
+  });
+}
+
+// PATCH /api/units/:id
+function updateUnit(req, res) {
+  const id = Number(req.params.id);
+  if (!id) return res.status(400).json({ error: 'Invalid unit id' });
+
+  const fields = [];
+  const params = [];
+  if (req.body.name !== undefined) { fields.push('name = ?'); params.push(req.body.name); }
+  if (req.body.type !== undefined) { fields.push('type = ?'); params.push(req.body.type); }
+  if (req.body.class !== undefined) { fields.push('class = ?'); params.push(req.body.class); }
+  if (req.body.tag !== undefined) { fields.push('tag = ?'); params.push(req.body.tag); }
+  if (req.body.priority !== undefined) {
+    let pr = Number(req.body.priority);
+    if (!Number.isFinite(pr)) pr = 1;
+    pr = Math.min(5, Math.max(1, pr));
+    fields.push('priority = ?');
+    params.push(pr);
+  }
+  if (!fields.length) return res.status(400).json({ error: 'No updatable fields provided' });
+  params.push(id);
+  const sql = `UPDATE units SET ${fields.join(', ')} WHERE id = ?`;
+  db.run(sql, params, function (err) {
+    if (err) return res.status(500).json({ error: err.message });
+    res.json({ success: true, changed: this.changes });
+  });
+}
+
+// PATCH /api/units/:id/status
+function patchStatus(req, res) {
+  const id = Number(req.params.id);
+  const status = String(req.body?.status || '').trim();
+  if (!id || !status) return res.status(400).json({ error: 'Invalid unit id/status' });
+  db.run('UPDATE units SET status=? WHERE id=?', [status, id], function (err) {
+    if (err) return res.status(500).json({ error: err.message });
+    res.json({ success: true, status });
+  });
+}
+
+// PATCH /api/units/:id/patrol
+function patchPatrol(req, res) {
+  const id = Number(req.params.id);
+  if (!id) return res.status(400).json({ error: 'Invalid unit id' });
+  const patrol = req.body && req.body.patrol ? 1 : 0;
+  db.run('UPDATE units SET patrol=? WHERE id=?', [patrol, id], function (err) {
+    if (err) return res.status(500).json({ error: err.message });
+    res.json({ success: true, patrol: Boolean(patrol) });
+  });
+}
+
+// PATCH /api/units/:id/icon
+function patchIcon(req, res) {
+  const id = Number(req.params.id);
+  const icon = req.body?.icon !== undefined ? String(req.body.icon).trim() : undefined;
+  const respondingIcon = req.body?.responding_icon !== undefined ? String(req.body.responding_icon).trim() : undefined;
+  if (!id) return res.status(400).json({ error: 'Invalid unit id' });
+  if (icon !== undefined && icon.length > 2048) return res.status(400).json({ error: 'Icon URL too long' });
+  if (respondingIcon !== undefined && respondingIcon.length > 2048) return res.status(400).json({ error: 'Icon URL too long' });
+  const sets = [];
+  const params = [];
+  if (icon !== undefined) { sets.push('icon=?'); params.push(icon); }
+  if (respondingIcon !== undefined) { sets.push('responding_icon=?'); params.push(respondingIcon); }
+  if (!sets.length) return res.status(400).json({ error: 'No icon provided' });
+  params.push(id);
+  db.run(`UPDATE units SET ${sets.join(', ')} WHERE id=?`, params, function (err) {
+    if (err) return res.status(500).json({ error: err.message });
+    res.json({ success: true, id, icon, responding_icon: respondingIcon });
+  });
+}
+
+// POST /api/units/:id/cancel
+function cancelUnit(req, res) {
+  const id = parseInt(req.params.id, 10);
+  if (!id) return res.status(400).json({ error: 'invalid id' });
+  db.serialize(() => {
+    db.all('SELECT mission_id FROM mission_units WHERE unit_id=?', [id], (err, rows) => {
+      if (err) return res.status(500).json({ error: err.message });
+      const missions = rows.map(r => r.mission_id);
+      db.run('DELETE FROM mission_units WHERE unit_id=?', [id]);
+      db.run('DELETE FROM unit_travel WHERE unit_id=?', [id]);
+      db.run('UPDATE units SET status=?, responding=0 WHERE id=?', ['available', id], function (err2) {
+        if (err2) return res.status(500).json({ error: err2.message });
+        res.json({ ok: true, missions });
+      });
+    });
+  });
+}
+
+module.exports = {
+  getUnits,
+  getUnit,
+  updateUnit,
+  patchStatus,
+  patchPatrol,
+  patchIcon,
+  cancelUnit,
+};

--- a/routes/missions.js
+++ b/routes/missions.js
@@ -1,0 +1,13 @@
+const express = require('express');
+const router = express.Router();
+const missions = require('../controllers/missionsController');
+
+router.get('/', missions.getMissions);
+router.post('/', missions.createMission);
+router.put('/:id', missions.updateMission);
+router.delete('/', missions.deleteMissions);
+router.post('/:id/timer', missions.startTimer);
+router.patch('/:id/timer', missions.modifyTimer);
+router.delete('/:id/timer', missions.clearTimer);
+
+module.exports = router;

--- a/routes/stations.js
+++ b/routes/stations.js
@@ -1,0 +1,11 @@
+const express = require('express');
+const router = express.Router();
+const stations = require('../controllers/stationsController');
+
+router.get('/', stations.getStations);
+router.get('/:id', stations.getStation);
+router.post('/', stations.createStation);
+router.patch('/:id/bays', stations.patchBays);
+router.delete('/', stations.deleteStations);
+
+module.exports = router;

--- a/routes/units.js
+++ b/routes/units.js
@@ -1,0 +1,13 @@
+const express = require('express');
+const router = express.Router();
+const units = require('../controllers/unitsController');
+
+router.get('/', units.getUnits);
+router.get('/:id', units.getUnit);
+router.patch('/:id', units.updateUnit);
+router.patch('/:id/status', units.patchStatus);
+router.patch('/:id/patrol', units.patchPatrol);
+router.patch('/:id/icon', units.patchIcon);
+router.post('/:id/cancel', units.cancelUnit);
+
+module.exports = router;

--- a/services/missionTimers.js
+++ b/services/missionTimers.js
@@ -1,0 +1,50 @@
+const db = require('../db');
+
+const missionClocks = new Map(); // mission_id -> { endAt, startedAt, baseDuration }
+
+function beginMissionClock(missionId, cb) {
+  db.get('SELECT timing, resolve_at FROM missions WHERE id=?', [missionId], (e, row) => {
+    if (e || !row) return cb && cb(null);
+
+    const baseDuration = Math.max(0, Number(row.timing || 0)) * 60 * 1000;
+    const existingDb = row.resolve_at != null ? Number(row.resolve_at) : null;
+    const now = Date.now();
+    if (existingDb && existingDb > now) {
+      const startedAt = existingDb - baseDuration;
+      missionClocks.set(missionId, { endAt: existingDb, startedAt, baseDuration });
+      return cb && cb(existingDb);
+    }
+
+    const endAt = now + baseDuration;
+    const startedAt = now;
+    db.run('UPDATE missions SET resolve_at=? WHERE id=?', [endAt, missionId], err => {
+      if (!err) missionClocks.set(missionId, { endAt, startedAt, baseDuration });
+      cb && cb(err ? null : endAt);
+    });
+  });
+}
+
+function clearMissionClock(missionId) {
+  missionClocks.delete(missionId);
+  db.run('UPDATE missions SET resolve_at=NULL WHERE id=?', [missionId], ()=>{});
+}
+
+function rehydrateMissionClocks() {
+  db.all('SELECT id, resolve_at, timing FROM missions WHERE resolve_at IS NOT NULL', (err, rows) => {
+    if (err) return;
+    const now = Date.now();
+    rows.forEach(r => {
+      const end = Number(r.resolve_at);
+      const baseDuration = Math.max(0, Number(r.timing || 0)) * 60 * 1000;
+      const startedAt = end - baseDuration;
+      if (end > now) missionClocks.set(r.id, { endAt: end, startedAt, baseDuration });
+    });
+  });
+}
+
+module.exports = {
+  missionClocks,
+  beginMissionClock,
+  clearMissionClock,
+  rehydrateMissionClocks,
+};

--- a/utils/index.js
+++ b/utils/index.js
@@ -1,0 +1,44 @@
+const axios = require('axios');
+
+// Safely parse JSON fields that should be arrays.
+function parseArrayField(str) {
+  try {
+    const val = JSON.parse(str || '[]');
+    if (Array.isArray(val)) return val;
+    if (val && typeof val === 'object') return [val];
+    return [];
+  } catch {
+    return [];
+  }
+}
+
+async function reverseGeocode(lat, lon) {
+  try {
+    const url = `https://nominatim.openstreetmap.org/reverse?format=jsonv2&lat=${lat}&lon=${lon}`;
+    const res = await axios.get(url, { headers: { 'User-Agent': '911ChiefResponder' } });
+    return res.data?.display_name || null;
+  } catch (e) {
+    console.error('Reverse geocode failed:', e.message);
+    return null;
+  }
+}
+
+// Simple point in polygon check for [lat, lon] coordinate arrays
+function pointInPolygon(lat, lon, poly) {
+  const pts = Array.isArray(poly?.coordinates) ? poly.coordinates : [];
+  let inside = false;
+  for (let i = 0, j = pts.length - 1; i < pts.length; j = i++) {
+    const xi = pts[i][1], yi = pts[i][0];
+    const xj = pts[j][1], yj = pts[j][0];
+    const intersect = ((yi > lat) !== (yj > lat)) &&
+      (lon < (xj - xi) * (lat - yi) / (yj - yi) + xi);
+    if (intersect) inside = !inside;
+  }
+  return inside;
+}
+
+module.exports = {
+  parseArrayField,
+  reverseGeocode,
+  pointInPolygon,
+};


### PR DESCRIPTION
## Summary
- split missions, stations and units endpoints into dedicated routers and controllers
- centralize parsing and geocode utilities
- add mission timer service

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68b77f35bf948328b3531ef6c51aa0fb