### PR TITLE
Fix missions query syntax

### DIFF
--- a/controllers/missionsController.js
+++ b/controllers/missionsController.js
@@ -5,7 +5,7 @@ const { beginMissionClock, clearMissionClock, missionClocks } = require('../serv
 // GET /api/missions
 async function getMissions(req, res) {
   const sql = `
-    SELECT m.,
+    SELECT m.*, 
            SUM(CASE WHEN u.status = 'enroute' THEN 1 ELSE 0 END) AS responding_count,
            SUM(CASE WHEN u.status IN ('enroute','on_scene') THEN 1 ELSE 0 END) AS assigned_count
     FROM missions m


### PR DESCRIPTION
## Summary
- correct SQL for mission listing to select all mission fields

## Testing
- `npm test` (fails: no test specified)


------
https://chatgpt.com/codex/tasks/task_e_68b77d2f0db48328914d348d7eb014e9