### PR TITLE
Use aeroway=aerodrome for airport POI dropdown

### DIFF
--- a/osmPoiTypes.js
+++ b/osmPoiTypes.js
@@ -1,5 +1,5 @@
 const OSM_POI_TYPES = [
-  "airport",
+  "aeroway=aerodrome",
   "large_airport",
   "atm",
   "bank",


### PR DESCRIPTION
## Summary
- Replace admin POI option `airport` with `aeroway=aerodrome`

## Testing
- `npm test` (fails: no test specified)

------
https://chatgpt.com/codex/tasks/task_e_68b7a7657c04832883281cba04e4b574