### PR TITLE
Fix station equipment purchases

### DIFF
--- a/controllers/stationsController.js
+++ b/controllers/stationsController.js
@@ -1,4 +1,5 @@
 const db = require('../db');
+const { findEquipmentCostByName, requireFunds, adjustBalance, getBalance } = require('../wallet');
 
 // GET /api/stations
 function getStations(req, res) {
@@ -56,10 +57,47 @@ function deleteStations(req, res) {
   });
 }
 
+// POST /api/stations/:id/equipment  { name: <string> }
+function buyEquipment(req, res) {
+  const stationId = Number(req.params.id);
+  const name = String(req.body?.name || '').trim();
+  if (!stationId || !name) return res.status(400).json({ error: 'Invalid station id or name' });
+
+  db.get(`SELECT equipment, equipment_slots FROM stations WHERE id=?`, [stationId], async (err, st) => {
+    if (err) return res.status(500).json({ error: err.message });
+    if (!st) return res.status(404).json({ error: 'Station not found' });
+
+    let list; try { list = JSON.parse(st.equipment || '[]'); } catch { list = []; }
+    const slots = Number(st.equipment_slots || 0);
+    if (slots && list.length >= slots) return res.status(409).json({ error: 'No free equipment slots' });
+
+    const cost = findEquipmentCostByName(name);
+    try {
+      const ok = await requireFunds(cost);
+      if (!ok.ok) return res.status(409).json({ error: 'Insufficient funds', balance: ok.balance, needed: cost });
+
+      list.push(name);
+      db.run(`UPDATE stations SET equipment=? WHERE id=?`, [JSON.stringify(list), stationId], async (e2) => {
+        if (e2) return res.status(500).json({ error: e2.message });
+        try {
+          await adjustBalance(-cost);
+          const balance = await getBalance();
+          res.json({ success: true, station_id: stationId, equipment: list, cost, balance });
+        } catch (e3) {
+          res.status(500).json({ error: e3.message });
+        }
+      });
+    } catch (e) {
+      res.status(500).json({ error: e.message });
+    }
+  });
+}
+
 module.exports = {
   getStations,
   getStation,
   createStation,
   patchBays,
   deleteStations,
+  buyEquipment,
 };

--- a/routes/stations.js
+++ b/routes/stations.js
@@ -7,5 +7,6 @@ router.get('/:id', stations.getStation);
 router.post('/', stations.createStation);
 router.patch('/:id/bays', stations.patchBays);
 router.delete('/', stations.deleteStations);
+router.post('/:id/equipment', stations.buyEquipment);
 
 module.exports = router;

--- a/wallet.js
+++ b/wallet.js
@@ -1,0 +1,45 @@
+const db = require('./db');
+let equipment = {};
+try { equipment = require('./equipment'); } catch { /* falls back to {} */ }
+
+function findEquipmentCostByName(name) {
+  try {
+    const lists = Object.values(equipment || {});
+    for (const arr of lists || []) {
+      for (const item of arr || []) {
+        if (typeof item === 'string' && item === name) return 0;
+        if (item?.name === name) return Number(item.cost) || 0;
+      }
+    }
+    return 0;
+  } catch { return 0; }
+}
+
+function getBalance() {
+  return new Promise((resolve, reject) => {
+    db.get(`SELECT balance FROM wallet WHERE id=1`, (e, row) =>
+      e ? reject(e) : resolve(Number(row?.balance || 0))
+    );
+  });
+}
+
+function adjustBalance(delta) {
+  return new Promise((resolve, reject) => {
+    db.run(`UPDATE wallet SET balance = balance + ? WHERE id=1`, [Number(delta) || 0],
+      function (e) { e ? reject(e) : resolve(true); });
+  });
+}
+
+async function requireFunds(amount) {
+  const need = Number(amount) || 0;
+  const bal = await getBalance();
+  if (bal < need) return { ok: false, balance: bal, need };
+  return { ok: true, balance: bal };
+}
+
+module.exports = {
+  findEquipmentCostByName,
+  getBalance,
+  adjustBalance,
+  requireFunds,
+};


### PR DESCRIPTION
## Summary
- move equipment purchase logic into controller and router
- share wallet utilities across modules

## Testing
- `npm test` *(fails: Error: no test specified)*
- `curl -s -X POST -H 'Content-Type: application/json' -d '{"name":"Ladder"}' http://localhost:911/api/stations/11/equipment`


------
https://chatgpt.com/codex/tasks/task_e_68b7aaa2381083288147901f22ad01de