### PR TITLE
feat(admin): add sticky save and auto-scroll

### DIFF
--- a/public/admin.html
+++ b/public/admin.html
@@ -12,6 +12,13 @@
       max-height: 80vh;
       overflow-y: auto;
     }
+    #mission-form-container .sticky-save {
+      position: sticky;
+      top: 0;
+      background: #fff;
+      padding: 5px 0;
+      z-index: 1;
+    }
     #mission-table-container {
       max-height: 80vh;
       overflow-y: auto;

--- a/public/admin.js
+++ b/public/admin.js
@@ -63,6 +63,8 @@ function appendMissionRow(mission) {
 async function openMissionForm(existing = null) {
   const c = document.getElementById("mission-form-container");
   c.style.display = "block";
+  c.scrollTop = 0;
+  window.scrollTo({ top: 0, behavior: 'smooth' });
 
   // ensure standalone run card editor is hidden when opening mission form
   const rcForm = document.getElementById('runcard-form-container');
@@ -72,6 +74,9 @@ async function openMissionForm(existing = null) {
   }
 
   c.innerHTML = `
+    <div class="sticky-save">
+      <button onclick="submitMission()">Save</button>
+    </div>
     <h3>${existing ? "Edit" : "New"} Mission</h3>
     <input type="hidden" id="mission-id" value="${existing?.id || ""}">
     <label>Name: <input id="mission-name" value="${existing?.name || ""}"></label><br>
@@ -133,8 +138,6 @@ async function openMissionForm(existing = null) {
     <div><strong>Equipment</strong></div>
     <div id="rc-equipment-container"></div>
     <button type="button" onclick="addRCEquipmentRow()">Add Equipment</button><br>
-
-    <button onclick="submitMission()">Save</button>
   `;
 
   buildTriggerFilterUI(existing?.trigger_type || '', existing?.trigger_filter || '');


### PR DESCRIPTION
## Summary
- Keep mission form's save button pinned to top with new sticky header
- Scroll to top and reset form position when opening mission editor

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68b7bb2bcad08328848345d1313a55ac