### PR TITLE
feat: replace confirm dialogs with modal

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -308,7 +308,7 @@ function colorForDept(d){
 }
 
 document.getElementById("deleteAllStations").addEventListener("click", async () => {
-  if (!confirm("Are you sure you want to delete ALL stations? This will also orphan units!")) return;
+  if (!await showConfirmModal("Are you sure you want to delete ALL stations? This will also orphan units!")) return;
   await fetch("/api/stations", { method: "DELETE" });
   fetchStations();
   alert("All stations deleted.");
@@ -1743,7 +1743,7 @@ document.getElementById('startPatrols').addEventListener('click', async () => {
 
 // Clear Missions
 document.getElementById("clearMissions").addEventListener("click", async ()=>{
-  if (!confirm("Clear ALL missions?")) return;
+  if (!await showConfirmModal("Clear ALL missions?")) return;
   await fetch("/api/missions", { method:"DELETE" });
   fetchMissions();
 });
@@ -1836,7 +1836,7 @@ async function openAssignModal(unitId, stationId) {
 }
 
 async function cancelUnit(unitId, stationId) {
-  if (!confirm('Cancel this unit?')) return;
+  if (!await showConfirmModal('Cancel this unit?')) return;
 
   let mission = null;
   try {

--- a/public/js/common.js
+++ b/public/js/common.js
@@ -51,9 +51,70 @@ export function playSound(path) {
   }
 }
 
+// Display a confirmation modal with the given message and return a Promise
+// that resolves to true if confirmed and false if cancelled. The modal uses
+// the existing `.modal-overlay` styles so it matches other overlays.
+export function showConfirmModal(message) {
+  return new Promise((resolve) => {
+    const overlay = document.createElement('div');
+    overlay.className = 'modal-overlay';
+
+    const content = document.createElement('div');
+    content.className = 'modal-content';
+
+    const msg = document.createElement('p');
+    msg.textContent = message;
+
+    const btnWrap = document.createElement('div');
+    btnWrap.style.textAlign = 'right';
+    btnWrap.style.marginTop = '1em';
+
+    const confirmBtn = document.createElement('button');
+    confirmBtn.textContent = 'Confirm';
+    const cancelBtn = document.createElement('button');
+    cancelBtn.textContent = 'Cancel';
+
+    btnWrap.appendChild(confirmBtn);
+    btnWrap.appendChild(cancelBtn);
+    content.appendChild(msg);
+    content.appendChild(btnWrap);
+    overlay.appendChild(content);
+    document.body.appendChild(overlay);
+
+    const focusable = [confirmBtn, cancelBtn];
+    const cleanup = (result) => {
+      overlay.remove();
+      document.removeEventListener('keydown', keyHandler);
+      resolve(result);
+    };
+    confirmBtn.addEventListener('click', () => cleanup(true));
+    cancelBtn.addEventListener('click', () => cleanup(false));
+    overlay.addEventListener('click', (e) => {
+      if (e.target === overlay) cleanup(false);
+    });
+
+    const keyHandler = (e) => {
+      if (e.key === 'Escape') {
+        e.preventDefault();
+        cleanup(false);
+      } else if (e.key === 'Tab') {
+        e.preventDefault();
+        let idx = focusable.indexOf(document.activeElement);
+        idx = e.shiftKey
+          ? (idx - 1 + focusable.length) % focusable.length
+          : (idx + 1) % focusable.length;
+        focusable[idx].focus();
+      }
+    };
+    document.addEventListener('keydown', keyHandler);
+    confirmBtn.focus();
+  });
+}
+
 // Expose helpers globally for legacy scripts
 window.fetchNoCache = fetchNoCache;
 window.haversineKm = haversineKm;
 window.formatTime = formatTime;
 window.formatStatus = formatStatus;
 window.playSound = playSound;
+window.showConfirmModal = showConfirmModal;


### PR DESCRIPTION
## Summary
- add reusable `showConfirmModal` helper with keyboard/ESC support
- replace native `confirm()` calls in index.html with `showConfirmModal`

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68b7c56daba08328b5a59c4f6556ca12