### PR TITLE
feat: add reusable modal form for zone and station creation

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -10,6 +10,7 @@
         <script src="https://cdnjs.cloudflare.com/ajax/libs/leaflet.draw/1.0.4/leaflet.draw.js"></script>
         <script src="https://cdn.jsdelivr.net/npm/@turf/turf@6/turf.min.js"></script>
         <script type="module" src="js/common.js"></script>
+        <script type="module" src="js/forms.js"></script>
         <script type="module" src="js/edit-dialogs.js"></script>
         <style>
                 html, body { height: 100%; margin: 0; overflow: hidden; }
@@ -1004,9 +1005,16 @@ document.getElementById('saveZoneEditBtn').addEventListener('click', async () =>
   layer.editing.disable();
   const latlngs = layer.getLatLngs()[0].map(p => [p.lat, p.lng]);
   const z = responseZones.find(r => r.id == id);
-  const name = prompt('Zone name:', z?.name || '') || (z?.name || '');
-  const deptInput = prompt('Departments (comma-separated):', (z?.departments||[]).join(', ')) || '';
-  const departments = deptInput.split(',').map(s=>s.trim()).filter(Boolean);
+  const result = await openFormModal({
+    title: 'Edit Zone',
+    fields: [
+      { name: 'name', label: 'Zone name', type: 'text', value: z?.name || '', required: true },
+      { name: 'departments', label: 'Departments (comma-separated)', type: 'text', value: (z?.departments||[]).join(', ') }
+    ]
+  });
+  if (!result) { editingZoneId = null; document.getElementById('saveZoneEditBtn').style.display = 'none'; fetchZones(); return; }
+  const name = result.name.trim() || (z?.name || '');
+  const departments = (result.departments || '').split(',').map(s=>s.trim()).filter(Boolean);
   await fetch(`/api/response-zones/${id}`, {
     method: 'PUT',
     headers: { 'Content-Type': 'application/json' },
@@ -1030,9 +1038,16 @@ map.on('draw:created', async e => {
   }
   const stations = await fetch('/api/stations').then(r => r.json());
   const depts = [...new Set(stations.map(s => s.department).filter(Boolean))];
-  const name = prompt('Zone name?') || 'Zone';
-  const deptInput = prompt(`Departments (comma-separated) (${depts.join(', ')})?`) || '';
-  const departments = deptInput.split(',').map(s=>s.trim()).filter(Boolean);
+  const result = await openFormModal({
+    title: 'Create Zone',
+    fields: [
+      { name: 'name', label: 'Zone name', type: 'text', value: 'Zone', required: true },
+      { name: 'departments', label: `Departments (comma-separated) (${depts.join(', ')})`, type: 'text' }
+    ]
+  });
+  if (!result) { map.removeLayer(e.layer); return; }
+  const name = result.name.trim() || 'Zone';
+  const departments = (result.departments || '').split(',').map(s=>s.trim()).filter(Boolean);
   const newPoly = turf.polygon([ring.map(([lat, lng]) => [lng, lat])]);
   for (const z of [...responseZones]) {
     const existingRing = z.polygon.coordinates.slice();
@@ -1586,17 +1601,25 @@ async function showStationDetails(station) {
 document.getElementById("buildStation").addEventListener("click", () => { buildStationMode = true; alert("Click the map to place your new station"); });
 map.on("click", async (e) => {
   if (!buildStationMode) return;
-  const name = prompt("Station Name?");
-  const type = prompt("Type (fire, police, ambulance, hospital, jail)?", "fire")?.toLowerCase();
-  const department = prompt("Department?") || null;
+  const result = await openFormModal({
+    title: 'Create Station',
+    fields: [
+      { name: 'name', label: 'Station Name', type: 'text', required: true },
+      { name: 'type', label: 'Type', type: 'select', value: 'fire', options: ['fire','police','ambulance','hospital','jail'], required: true },
+      { name: 'department', label: 'Department', type: 'text' },
+      { name: 'holding_cells', label: 'Holding cells', type: 'number', value: 0, min: 0, showIf: v => ['police','jail'].includes((v.type||'').toLowerCase()) },
+      { name: 'beds', label: 'Beds', type: 'number', value: 0, min: 0, showIf: v => (v.type||'').toLowerCase() === 'hospital' }
+    ]
+  });
+  if (!result) { buildStationMode = false; pendingStationCoords = null; return; }
+  const name = result.name.trim();
+  const type = (result.type || '').toLowerCase();
+  const department = result.department ? result.department.trim() : null;
   if (!name || !["fire","police","ambulance","hospital","jail"].includes(type)) { alert("Cancelled or invalid type."); buildStationMode=false; return; }
-  let holding_cells = 0, beds = 0;
-  if (type === "police" || type === "jail") {
-    holding_cells = Number(prompt("Holding cells?", "0")) || 0;
-  }
-  if (type === "hospital") {
-    beds = Number(prompt("Beds?", "0")) || 0;
-  }
+  let holding_cells = Number(result.holding_cells) || 0;
+  let beds = Number(result.beds) || 0;
+  if (!['police','jail'].includes(type)) holding_cells = 0;
+  if (type !== 'hospital') beds = 0;
   await fetch("/api/stations", { method:"POST", headers:{ "Content-Type":"application/json" }, body: JSON.stringify({ name, type, department, lat:e.latlng.lat, lon:e.latlng.lng, holding_cells, beds }) });
   buildStationMode = false;
   pendingStationCoords = null;

--- a/public/js/forms.js
+++ b/public/js/forms.js
@@ -1,0 +1,145 @@
+export function openFormModal(opts = {}) {
+  return new Promise(resolve => {
+    const overlay = document.createElement('div');
+    overlay.className = 'modal-overlay';
+    const content = document.createElement('div');
+    content.className = 'modal-content';
+
+    const form = document.createElement('form');
+    form.style.display = 'flex';
+    form.style.flexDirection = 'column';
+    form.style.gap = '10px';
+
+    if (opts.title) {
+      const h3 = document.createElement('h3');
+      h3.textContent = opts.title;
+      form.appendChild(h3);
+    }
+
+    const fieldStates = [];
+    (opts.fields || []).forEach(f => {
+      const wrapper = document.createElement('div');
+      wrapper.style.display = 'flex';
+      wrapper.style.flexDirection = 'column';
+      const label = document.createElement('label');
+      label.textContent = f.label || f.name || '';
+      label.style.marginBottom = '4px';
+      let input;
+      if (f.type === 'select') {
+        input = document.createElement('select');
+        (f.options || []).forEach(opt => {
+          const option = document.createElement('option');
+          if (typeof opt === 'object') {
+            option.value = opt.value;
+            option.textContent = opt.label;
+          } else {
+            option.value = option.textContent = opt;
+          }
+          input.appendChild(option);
+        });
+        if (f.value != null) input.value = f.value;
+      } else {
+        input = document.createElement('input');
+        input.type = f.type || 'text';
+        if (f.value != null) input.value = f.value;
+        if (f.min != null) input.min = f.min;
+        if (f.max != null) input.max = f.max;
+        if (f.step != null) input.step = f.step;
+      }
+      input.style.width = '100%';
+      if (f.placeholder) input.placeholder = f.placeholder;
+      wrapper.appendChild(label);
+      wrapper.appendChild(input);
+      const err = document.createElement('div');
+      err.style.color = 'red';
+      err.style.fontSize = '0.9em';
+      err.style.display = 'none';
+      wrapper.appendChild(err);
+      form.appendChild(wrapper);
+      fieldStates.push({ field: f, input, err, wrapper });
+    });
+
+    const btnRow = document.createElement('div');
+    btnRow.style.display = 'flex';
+    btnRow.style.gap = '8px';
+    btnRow.style.justifyContent = 'flex-end';
+    const cancelBtn = document.createElement('button');
+    cancelBtn.type = 'button';
+    cancelBtn.textContent = 'Cancel';
+    const saveBtn = document.createElement('button');
+    saveBtn.type = 'submit';
+    saveBtn.textContent = 'Save';
+    saveBtn.style.background = '#0b5';
+    saveBtn.style.color = '#fff';
+    btnRow.appendChild(cancelBtn);
+    btnRow.appendChild(saveBtn);
+    form.appendChild(btnRow);
+
+    content.appendChild(form);
+    overlay.appendChild(content);
+    document.body.appendChild(overlay);
+
+    const close = res => {
+      document.body.removeChild(overlay);
+      resolve(res);
+    };
+
+    cancelBtn.onclick = () => close(null);
+    overlay.addEventListener('click', e => { if (e.target === overlay) close(null); });
+
+    function currentValues() {
+      const vals = {};
+      fieldStates.forEach(s => {
+        if (s.wrapper.style.display === 'none') return;
+        vals[s.field.name] = s.input.value;
+      });
+      return vals;
+    }
+
+    function updateVisibility() {
+      const vals = currentValues();
+      fieldStates.forEach(s => {
+        const show = typeof s.field.showIf === 'function' ? !!s.field.showIf(vals) : true;
+        s.wrapper.style.display = show ? 'flex' : 'none';
+      });
+    }
+    fieldStates.forEach(s => {
+      s.input.addEventListener('input', updateVisibility);
+      s.input.addEventListener('change', updateVisibility);
+    });
+    updateVisibility();
+
+    form.addEventListener('submit', e => {
+      e.preventDefault();
+      const vals = currentValues();
+      let ok = true;
+      fieldStates.forEach(s => {
+        if (s.wrapper.style.display === 'none') { s.err.style.display = 'none'; return; }
+        const v = s.input.value;
+        if (s.field.required && !v) {
+          s.err.textContent = s.field.requiredMessage || 'This field is required';
+          s.err.style.display = 'block';
+          ok = false;
+          return;
+        }
+        if (typeof s.field.validator === 'function') {
+          const res = s.field.validator(v, vals);
+          if (res !== true && res !== undefined && res !== null && res !== '') {
+            s.err.textContent = typeof res === 'string' ? res : 'Invalid value';
+            s.err.style.display = 'block';
+            ok = false;
+            return;
+          }
+        }
+        s.err.style.display = 'none';
+      });
+      if (!ok) return;
+      close(vals);
+    });
+  });
+}
+
+if (typeof window !== 'undefined') {
+  window.openFormModal = openFormModal;
+}
+


### PR DESCRIPTION
## Summary
- build generic modal form component supporting dynamic fields and validation
- use modal form instead of prompt() for editing/creating zones
- replace station creation prompts with modal form and conditional fields

## Testing
- `npm test` (fails: Error: no test specified)


------
https://chatgpt.com/codex/tasks/task_e_68b7c64e669c8328b5bd7627047327e4