### PR TITLE
Use center coordinates for area POIs

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1690,7 +1690,11 @@ async function generateMission(retry = false, excludeIndex = null) {
       });
       if (matches.length) {
         const poi = matches[Math.floor(Math.random() * matches.length)];
-        lat = poi.lat; lon = poi.lon;
+        // `poi` may be an area (way/relation) from Overpass which stores its
+        // coordinates under `center`.  Use those center coordinates if direct
+        // lat/lon are not provided so the mission spawns at the POI itself.
+        lat = poi.lat ?? poi.center?.lat;
+        lon = poi.lon ?? poi.center?.lon;
       } else {
         console.warn(`No matching POI found for mission template "${template?.name || template?.id}" (ID: ${template?.id})`, template);
         if (!retry) return generateMission(true, templateIndex);

--- a/public/js/cad.js
+++ b/public/js/cad.js
@@ -971,7 +971,11 @@ export async function generateMission(retry = false, excludeIndex = null) {
       });
       if (matches.length) {
         const poi = matches[Math.floor(Math.random() * matches.length)];
-        lat = poi.lat; lon = poi.lon;
+        // Overpass area POIs provide coordinates in a `center` object.
+        // Use those when direct lat/lon are missing so missions spawn
+        // at the correct POI location.
+        lat = poi.lat ?? poi.center?.lat;
+        lon = poi.lon ?? poi.center?.lon;
       } else {
         console.warn(`No matching POI found for mission template "${template?.name || template?.id}" (ID: ${template?.id})`, template);
         if (!retry) return generateMission(true, templateIndex);


### PR DESCRIPTION
## Summary
- Normalize Overpass POI responses to include lat/lon for area features
- Use center coordinates in mission generation so POI-triggered calls spawn at the actual POI

## Testing
- `npm test` (fails: Error: no test specified)


------
https://chatgpt.com/codex/tasks/task_e_68b7cdce821483289cdc36ab8d713436