### PR TITLE
Add mobile-friendly tabbed interface

### DIFF
--- a/public/js/mobile.js
+++ b/public/js/mobile.js
@@ -1,0 +1,104 @@
+// Mobile UI script
+
+// Tab navigation
+const tabButtons = document.querySelectorAll('.tab-bar button');
+const tabs = document.querySelectorAll('.tab');
+
+function activateTab(id) {
+  tabs.forEach(t => t.classList.remove('active'));
+  const el = document.getElementById(id);
+  if (el) el.classList.add('active');
+}
+
+tabButtons.forEach(btn => {
+  btn.addEventListener('click', () => activateTab(btn.dataset.tab));
+});
+
+// Modal helper
+const modal = document.getElementById('modal');
+const modalContent = document.getElementById('modalContent');
+
+function showModal(html) {
+  modalContent.innerHTML = html + '<br/><button id="modalClose">Close</button>';
+  modal.style.display = 'flex';
+  document.getElementById('modalClose').onclick = () => { modal.style.display = 'none'; };
+}
+
+modal.addEventListener('click', (e) => {
+  if (e.target === modal) modal.style.display = 'none';
+});
+
+// Map setup
+const map = L.map('map').setView([0,0],2);
+L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+  attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
+}).addTo(map);
+
+let stationById = new Map();
+
+async function loadData() {
+  const [missions, stations, units] = await Promise.all([
+    fetch('/api/missions').then(r=>r.json()),
+    fetch('/api/stations').then(r=>r.json()),
+    fetch('/api/units').then(r=>r.json())
+  ]);
+
+  stationById = new Map(stations.map(s => [s.id, s]));
+
+  renderStations(stations);
+  renderMissions(missions);
+  renderUnits(units);
+  renderMap(missions, stations, units);
+}
+
+function renderMap(missions, stations, units){
+  // clear existing layers
+  if (window._mapLayers) window._mapLayers.forEach(l => map.removeLayer(l));
+  window._mapLayers = [];
+
+  stations.forEach(s => {
+    const m = L.circleMarker([s.lat, s.lon], {color:'blue'}).addTo(map);
+    m.on('click', () => showModal(`<h3>Station ${s.name}</h3>`));
+    window._mapLayers.push(m);
+  });
+
+  missions.forEach(mis => {
+    const m = L.circleMarker([mis.lat, mis.lon], {color:'red'}).addTo(map);
+    m.on('click', () => showModal(`<h3>Mission ${mis.id}</h3><p>${mis.type}</p>`));
+    window._mapLayers.push(m);
+  });
+
+  units.forEach(u => {
+    const st = stationById.get(u.station_id);
+    if (!st) return;
+    const m = L.circleMarker([st.lat, st.lon], {color:'green'}).addTo(map);
+    m.on('click', () => showModal(`<h3>Unit ${u.name || u.id}</h3><p>Status: ${u.status}</p>`));
+    window._mapLayers.push(m);
+  });
+}
+
+function renderList(containerId, items, renderer){
+  const el = document.getElementById(containerId);
+  el.innerHTML = '';
+  items.forEach(item => {
+    const div = document.createElement('div');
+    div.className = 'list-item';
+    div.innerHTML = renderer(item);
+    div.addEventListener('click', () => showModal(renderer(item)));
+    el.appendChild(div);
+  });
+}
+
+function renderMissions(missions){
+  renderList('missionsTab', missions, m => `Mission ${m.id}: ${m.type}`);
+}
+
+function renderStations(stations){
+  renderList('stationsTab', stations, s => `Station ${s.id}: ${s.name}`);
+}
+
+function renderUnits(units){
+  renderList('unitsTab', units, u => `Unit ${u.id}: ${u.name || u.type}`);
+}
+
+loadData();

--- a/public/mobile.html
+++ b/public/mobile.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Chief Responder Mobile</title>
+  <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" integrity="sha256-sA+e2GV4lZF8X3Y+5Sz4o9FmkIoDxdky1KZY1Hq0LEQ=" crossorigin="" />
+  <style>
+    body,html { margin:0; padding:0; height:100%; font-family: Arial, sans-serif; }
+    .tab { display:none; height:calc(100vh - 50px); overflow-y:auto; }
+    .tab.active { display:block; }
+    #map { height:100%; width:100%; }
+    .tab-bar { position:fixed; bottom:0; left:0; right:0; height:50px; display:flex; background:#222; color:#fff; }
+    .tab-bar button { flex:1; border:none; background:none; color:inherit; font-size:16px; }
+    .list-item { padding:10px; border-bottom:1px solid #ccc; }
+    .modal { display:none; position:fixed; top:0; left:0; right:0; bottom:0; background:rgba(0,0,0,0.5); align-items:center; justify-content:center; }
+    .modal-content { background:#fff; padding:20px; max-width:90%; }
+  </style>
+</head>
+<body>
+  <div id="mapTab" class="tab active"><div id="map"></div></div>
+  <div id="missionsTab" class="tab"></div>
+  <div id="stationsTab" class="tab"></div>
+  <div id="unitsTab" class="tab"></div>
+
+  <div class="tab-bar">
+    <button data-tab="mapTab">Map</button>
+    <button data-tab="missionsTab">Calls</button>
+    <button data-tab="stationsTab">Stations</button>
+    <button data-tab="unitsTab">Units</button>
+  </div>
+
+  <div id="modal" class="modal">
+    <div class="modal-content" id="modalContent"></div>
+  </div>
+
+  <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js" integrity="sha256-o9N1j8r6RgkP7X7C4CkVkFv7Yj5YzJ4q35p3l0w0a2I=" crossorigin=""></script>
+  <script src="js/mobile.js"></script>
+</body>
+</html>

--- a/server.js
+++ b/server.js
@@ -2068,6 +2068,10 @@ app.get('/admin', (req, res) => {
   res.sendFile(path.join(__dirname, 'admin.html'));
 });
 
+app.get('/mobile', (req, res) => {
+  res.sendFile(path.join(__dirname, 'public', 'mobile.html'));
+});
+
 // Periodically process unit travel arrivals/returns so missions can progress
 setInterval(() => {
   db.all('SELECT * FROM unit_travel', (err, rows) => {


### PR DESCRIPTION
## Summary
- Create `mobile.html` with tabbed layout for map, calls, stations, and units
- Add `mobile.js` to fetch data and display markers and lists with popups
- Expose new `/mobile` route to serve the mobile page

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68b7e311c26883288d0d16e759086cf1