### PR TITLE
Fix mobile tab navigation for older browsers

### DIFF
--- a/public/js/mobile.js
+++ b/public/js/mobile.js
@@ -5,14 +5,14 @@ const tabButtons = document.querySelectorAll('.tab-bar button');
 const tabs = document.querySelectorAll('.tab');
 
 function activateTab(id) {
-  tabs.forEach(t => t.classList.remove('active'));
+  for (const t of tabs) t.classList.remove('active');
   const el = document.getElementById(id);
   if (el) el.classList.add('active');
 }
 
-tabButtons.forEach(btn => {
+for (const btn of tabButtons) {
   btn.addEventListener('click', () => activateTab(btn.dataset.tab));
-});
+}
 
 // Modal helper
 const modal = document.getElementById('modal');


### PR DESCRIPTION
## Summary
- Use `for...of` loops for tab buttons to avoid `NodeList.forEach` incompatibility

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68b7f91706a083289bb9f30ac40e4aeb