### PR TITLE
Fix Leaflet.draw compatibility by using Leaflet 1.7.1

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -4,8 +4,8 @@
 	<meta charset="UTF-8" />
 	<meta name="viewport" content="width=device-width, initial-scale=1.0" />
 	<title>Chief Responder</title>
-        <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" />
-        <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
+        <link rel="stylesheet" href="https://unpkg.com/leaflet@1.7.1/dist/leaflet.css" />
+        <script src="https://unpkg.com/leaflet@1.7.1/dist/leaflet.js"></script>
         <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/leaflet.draw/1.0.4/leaflet.draw.css" />
         <script src="https://cdnjs.cloudflare.com/ajax/libs/leaflet.draw/1.0.4/leaflet.draw.js"></script>
         <script src="https://cdn.jsdelivr.net/npm/@turf/turf@6/turf.min.js"></script>


### PR DESCRIPTION
## Summary
- Downgrade Leaflet to v1.7.1 for compatibility with leaflet.draw 1.0.4

## Testing
- `npm test` *(fails: no test specified)*
- `node puppeteer script` *(fails: libatk-1.0.so.0 cannot open shared object file)*

------
https://chatgpt.com/codex/tasks/task_e_68b966a03c788328b70d2803f1632245