### PR TITLE
Add office building POI type

### DIFF
--- a/osmPoiTypes.js
+++ b/osmPoiTypes.js
@@ -15,6 +15,7 @@ const OSM_POI_TYPES = [
   "amenity=fire_station",
   "amenity=fuel",
   "building=house",
+  "building=office",
   "amenity=hospital",
   "landuse=landfill",
   "amenity=library",


### PR DESCRIPTION
## Summary
- include `building=office` in supported OSM POI types for mission templates

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68b96b8242e883289218d4387eef5479