### PR TITLE
feat: add station icon patch endpoint

### DIFF
--- a/controllers/stationsController.js
+++ b/controllers/stationsController.js
@@ -49,6 +49,18 @@ function patchBays(req, res) {
   });
 }
 
+// PATCH /api/stations/:id/icon  { icon: <string> }
+function patchIcon(req, res) {
+  const id = Number(req.params.id);
+  const icon = String(req.body?.icon || '').trim();
+  if (!id) return res.status(400).json({ error: 'Invalid station id' });
+  if (icon.length > 2048) return res.status(400).json({ error: 'Icon URL too long' });
+  db.run('UPDATE stations SET icon=? WHERE id=?', [icon, id], function (err) {
+    if (err) return res.status(500).json({ error: err.message });
+    res.json({ success: true, id, icon });
+  });
+}
+
 // DELETE /api/stations
 function deleteStations(req, res) {
   db.run('DELETE FROM stations', err => {
@@ -98,6 +110,7 @@ module.exports = {
   getStation,
   createStation,
   patchBays,
+  patchIcon,
   deleteStations,
   buyEquipment,
 };

--- a/routes/stations.js
+++ b/routes/stations.js
@@ -6,6 +6,7 @@ router.get('/', stations.getStations);
 router.get('/:id', stations.getStation);
 router.post('/', stations.createStation);
 router.patch('/:id/bays', stations.patchBays);
+router.patch('/:id/icon', stations.patchIcon);
 router.delete('/', stations.deleteStations);
 router.post('/:id/equipment', stations.buyEquipment);
 

--- a/server.js
+++ b/server.js
@@ -1240,17 +1240,6 @@ app.patch('/api/stations/:id/equipment-slots', (req, res) => {
     });
   });
 });
-// PATCH /api/stations/:id/icon  { icon: <string> }
-app.patch('/api/stations/:id/icon', (req, res) => {
-  const id = Number(req.params.id);
-  const icon = String(req.body?.icon || '').trim();
-  if (!id) return res.status(400).json({ error: 'Invalid station id' });
-  if (icon.length > 2048) return res.status(400).json({ error: 'Icon URL too long' });
-  db.run(`UPDATE stations SET icon=? WHERE id=?`, [icon, id], function (err) {
-    if (err) return res.status(500).json({ error: err.message });
-    res.json({ success: true, id, icon });
-  });
-});
 
 // PATCH /api/stations/:id/department  { department: <string> }
 app.patch('/api/stations/:id/department', (req, res) => {


### PR DESCRIPTION
## Summary
- support updating a station's icon through `PATCH /api/stations/:id/icon`
- wire the new handler through the stations router
- remove legacy icon patch block from server

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68b96da14ba0832883e7bf530a0d60fc