### PR TITLE
Await station marker fallback after icon update

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1410,7 +1410,7 @@ async function showStationDetails(station) {
         marker.setIcon(makeIcon(url, 30));
       } catch (err) {
         console.error(err);
-        fetchStations();
+        await fetchStations();
       }
       showStationDetails(station);
     });
@@ -1524,7 +1524,7 @@ async function showStationDetails(station) {
                   marker.setIcon(makeIcon(url, 30));
                 } catch (err) {
                   console.error(err);
-                  fetchStations();
+                  await fetchStations();
                 }
                 showStationDetails(station);
           });


### PR DESCRIPTION
## Summary
- Await fetchStations when updating station icon fails to refresh existing marker

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68b981aab6ac8328a5b9813378faf4da