### PR TITLE
chore: update leaflet library

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -4,8 +4,8 @@
 	<meta charset="UTF-8" />
 	<meta name="viewport" content="width=device-width, initial-scale=1.0" />
 	<title>Chief Responder</title>
-        <link rel="stylesheet" href="https://unpkg.com/leaflet@1.7.1/dist/leaflet.css" />
-        <script src="https://unpkg.com/leaflet@1.7.1/dist/leaflet.js"></script>
+        <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" />
+        <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
         <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/leaflet.draw/1.0.4/leaflet.draw.css" />
         <script src="https://cdnjs.cloudflare.com/ajax/libs/leaflet.draw/1.0.4/leaflet.draw.js"></script>
         <script src="https://cdn.jsdelivr.net/npm/@turf/turf@6/turf.min.js"></script>


### PR DESCRIPTION
## Summary
- update Leaflet to 1.9.4 for improved compatibility

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npx playwright@1.55.0 install firefox` *(fails: host missing browser dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68b97cfa974c8328b49bcae0c5eeb808