### PR TITLE
fix: correct Leaflet SRI hashes for mobile

### DIFF
--- a/public/mobile.html
+++ b/public/mobile.html
@@ -4,7 +4,12 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Chief Responder Mobile</title>
-  <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" integrity="sha256-sA+e2GV4lZF8X3Y+5Sz4o9FmkIoDxdky1KZY1Hq0LEQ=" crossorigin="" />
+  <link
+    rel="stylesheet"
+    href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css"
+    integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY="
+    crossorigin=""
+  />
   <style>
     body,html { margin:0; padding:0; height:100%; font-family: Arial, sans-serif; }
     .tab { display:none; height:calc(100vh - 50px); overflow-y:auto; }
@@ -34,7 +39,11 @@
     <div class="modal-content" id="modalContent"></div>
   </div>
 
-  <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js" integrity="sha256-o9N1j8r6RgkP7X7C4CkVkFv7Yj5YzJ4q35p3l0w0a2I=" crossorigin=""></script>
+  <script
+    src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"
+    integrity="sha256-20nQCchB9co0qIjJZRGuk2/Z9VM+kNiyxNV1lvTlZBo="
+    crossorigin=""
+  ></script>
   <script src="js/mobile.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- correct integrity hashes for Leaflet CSS/JS in mobile.html

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68b991117cec83288da53de1bff4800b