### PR TITLE
Add unit type travel speeds with class fallbacks

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -259,7 +259,11 @@
 
 <script>
 // ========= constants / helpers =========
-const TRAVEL_SPEED = { fire: 63, police: 94, ambulance: 75, sar: 70 }; // km/h used across UI (25% faster)
+const CLASS_SPEED = { fire: 63, police: 94, ambulance: 75, sar: 70 }; // km/h used across UI (25% faster)
+const TRAVEL_SPEED = unitTypes.reduce((acc, u) => {
+  acc[u.type] = u.speed || CLASS_SPEED[u.class] || 63;
+  return acc;
+}, {});
 
 function haversineKm(aLat, aLon, bLat, bLon) {
   const R = 6371;
@@ -916,7 +920,7 @@ function startUnitPatrol(unit) {
   const st = _stationById.get(unit.station_id);
   if (!st) return;
   ensureUnitMarker(unit);
-  const speed = TRAVEL_SPEED[unit.class] || 63;
+  const speed = TRAVEL_SPEED[unit.type] || CLASS_SPEED[unit.class] || 63;
   const state = { start: Date.now() };
   patrolStates.set(unit.id, state);
   const maxMs = 60 * 60 * 1000;
@@ -2026,7 +2030,7 @@ async function cancelUnit(unitId, stationId) {
         unit.id,
         [current.lat, current.lng],
         [st.lat, st.lon],
-          TRAVEL_SPEED[unit.class] || 56,
+          TRAVEL_SPEED[unit.type] || CLASS_SPEED[unit.class] || 56,
         () => {
           const rp = unitRoutes.get(unit.id);
           if (rp) { try { map.removeLayer(rp); } catch {} unitRoutes.delete(unit.id); }
@@ -2452,7 +2456,7 @@ async function openManualDispatch(mission) {
     const current = marker.getLatLng ? marker.getLatLng() : L.latLng(st.lat, st.lon);
     const from = [current.lat, current.lng];
     const to   = [mission.lat, mission.lon];
-      const spd  = TRAVEL_SPEED[u.class] || 56;
+      const spd  = TRAVEL_SPEED[u.type] || CLASS_SPEED[u.class] || 56;
 
     routeAndAnimateUnit(
       uid, from, to, spd,
@@ -2718,7 +2722,7 @@ async function clearAssignedUnit(missionId, unitId) {
     const from = [current.lat, current.lng];
     const to   = [st.lat, st.lon];
     routeAndAnimateUnit(
-        u.id, from, to, TRAVEL_SPEED[u.class] || 56,
+        u.id, from, to, TRAVEL_SPEED[u.type] || CLASS_SPEED[u.class] || 56,
       () => { const rp = unitRoutes.get(u.id); if (rp){ try{ map.removeLayer(rp); }catch{} unitRoutes.delete(u.id); } fetch(`/api/unit-travel/${u.id}`,{method:'DELETE'}).catch(()=>{}); },
       { phase: 'return' }
     );
@@ -2814,7 +2818,7 @@ function setupTimerForMission(mission, endTime) {
         u.id,
         [current.lat, current.lng],
         [st.lat, st.lon],
-          TRAVEL_SPEED[u.class] || 56,
+          TRAVEL_SPEED[u.type] || CLASS_SPEED[u.class] || 56,
         () => {
           const rp = unitRoutes.get(u.id);
           if (rp) { try { map.removeLayer(rp); } catch {} unitRoutes.delete(u.id); }
@@ -2858,7 +2862,7 @@ async function rebuildEnrouteMarkers() {
       if (!u) continue;
       ensureUnitMarker(u);
       routeAndAnimateUnit(
-          t.unit_id, t.from, t.to, TRAVEL_SPEED[u.class] || 56,
+          t.unit_id, t.from, t.to, TRAVEL_SPEED[u.type] || CLASS_SPEED[u.class] || 56,
         async () => {
           if (t.phase === 'to_scene') {
             await fetch(`/api/units/${t.unit_id}/status`, { method:'PATCH', headers:{'Content-Type':'application/json'}, body: JSON.stringify({ status: 'on_scene' }) });
@@ -2893,7 +2897,7 @@ async function rebuildEnrouteMarkers() {
           const st = _stationById.get(u.station_id);
           if (!st) continue;
           ensureUnitMarker(u);
-            routeAndAnimateUnit(u.id, [st.lat, st.lon], [m.lat, m.lon], TRAVEL_SPEED[u.class] || 56, async ()=>{
+            routeAndAnimateUnit(u.id, [st.lat, st.lon], [m.lat, m.lon], TRAVEL_SPEED[u.type] || CLASS_SPEED[u.class] || 56, async ()=>{
             await fetch(`/api/units/${u.id}/status`, { method:'PATCH', headers:{'Content-Type':'application/json'}, body: JSON.stringify({ status: 'on_scene' }) });
             const entry = unitMarkers.get(u.id); if (entry){ try{ map.removeLayer(entry.marker); }catch{} unitMarkers.delete(u.id); }
             const rp = unitRoutes.get(u.id); if (rp){ try{ map.removeLayer(rp); }catch{} unitRoutes.delete(u.id); }

--- a/server.js
+++ b/server.js
@@ -23,7 +23,7 @@ db.serialize(() => {
 
 const { parseArrayField, reverseGeocode, pointInPolygon } = require('./utils');
 
-const TRAVEL_SPEED = { fire: 63, police: 94, ambulance: 75, sar: 70 }; // km/h (25% faster)
+const CLASS_SPEED = { fire: 63, police: 94, ambulance: 75, sar: 70 }; // km/h (25% faster)
 function haversine(aLat, aLon, bLat, bLon) {
   const R = 6371;
   const dLat = (bLat - aLat) * Math.PI / 180;
@@ -321,7 +321,7 @@ async function allocateTransport(kind, lat, lon, unitClass) {
     f.distance = haversine(lat, lon, f.lat, f.lon);
   });
   facilities.sort((a, b) => a.distance - b.distance);
-  const speed = TRAVEL_SPEED[unitClass] || 63;
+  const speed = CLASS_SPEED[unitClass] || 63;
   const now = Date.now();
   for (let i = 0; i < facilities.length; i++) {
     const f = facilities[i];

--- a/unitTypes.js
+++ b/unitTypes.js
@@ -1,29 +1,38 @@
+const CLASS_SPEED = { fire: 63, police: 94, ambulance: 75, sar: 70 };
+
 const unitTypes = [
-  { class: "fire", type: "Engine",            capacity: 6, equipmentSlots: 3, attributes: ["waterTank"], cost: 12000 },
-  { class: "fire", type: "Ladder",            capacity: 4, equipmentSlots: 2, attributes: ["ladder"], cost: 18000 },
-  { class: "fire", type: "Chief",             capacity: 2, equipmentSlots: 2, attributes: [], cost: 8000  },
-  { class: "fire", type: "Rescue",            capacity: 4, equipmentSlots: 2, attributes: [], cost: 15000 },
-  { class: "fire", type: "Special Operations",capacity: 4, equipmentSlots: 2, attributes: [], cost: 22000 },
-  { class: "fire", type: "Tanker", 			  capacity: 4, equipmentSlots: 2, attributes: ["tanker"], cost: 12000 },
-  { class: "fire", type: "Support Unit",      capacity: 2, equipmentSlots: 4, attributes: [], cost: 5000 },
-  { class: "fire", type: "ARFF",              capacity: 2, equipmentSlots: 4, attributes: ["foam"], cost: 8000 },
-  
-  { class: "ambulance", type: "Ambulance",    capacity: 2, equipmentSlots: 1, attributes: ["medicaltransport"], cost: 14000 },
-  { class: "ambulance", type: "Fly-car",      capacity: 2, equipmentSlots: 1, attributes: [], cost: 9000  },
-  { class: "ambulance", type: "Supervisor",   capacity: 4, equipmentSlots: 2, attributes: [], cost: 10000 },
-  { class: "ambulance", type: "Mass Casualty",capacity: 4, equipmentSlots: 2, attributes: ["medicaltransport"],  cost: 25000 },
-  { class: "ambulance", type: "Inter-facility Transport", capacity: 2, equipmentSlots: 1, attributes: ["medicaltransport"], cost: 13000 },
+  { class: "fire", type: "Engine",            capacity: 6, equipmentSlots: 3, attributes: ["waterTank"], cost: 12000, speed: 65 },
+  { class: "fire", type: "Ladder",            capacity: 4, equipmentSlots: 2, attributes: ["ladder"], cost: 18000, speed: 60 },
+  { class: "fire", type: "Chief",             capacity: 2, equipmentSlots: 2, attributes: [], cost: 8000,  speed: 75 },
+  { class: "fire", type: "Rescue",            capacity: 4, equipmentSlots: 2, attributes: [], cost: 15000, speed: 65 },
+  { class: "fire", type: "Special Operations",capacity: 4, equipmentSlots: 2, attributes: [], cost: 22000, speed: 75 },
+  { class: "fire", type: "Tanker",            capacity: 4, equipmentSlots: 2, attributes: ["tanker"], cost: 12000, speed: 55 },
+  { class: "fire", type: "Support Unit",      capacity: 2, equipmentSlots: 4, attributes: [], cost: 5000,  speed: 70 },
+  { class: "fire", type: "ARFF",              capacity: 2, equipmentSlots: 4, attributes: ["foam"], cost: 8000,  speed: 60 },
 
-  { class: "police", type: "Patrol Car",      capacity: 2, equipmentSlots: 2, attributes: ["prisonerTransport"], cost: 9000  },
-  { class: "police", type: "Unmarked Car",    capacity: 4, equipmentSlots: 2, attributes: [], cost: 9500  },
-  { class: "police", type: "Special Services", capacity: 4, equipmentSlots: 4, attributes: [], cost: 20000 },
-  { class: "police", type: "SWAT Van",        capacity: 6, equipmentSlots: 4, attributes: ["armor","SWAT"], cost: 30000 },
+  { class: "ambulance", type: "Ambulance",    capacity: 2, equipmentSlots: 1, attributes: ["medicaltransport"], cost: 14000, speed: 60 },
+  { class: "ambulance", type: "Fly-car",      capacity: 2, equipmentSlots: 1, attributes: [], cost: 9000,  speed: 75 },
+  { class: "ambulance", type: "Supervisor",   capacity: 4, equipmentSlots: 2, attributes: [], cost: 10000, speed: 75 },
+  { class: "ambulance", type: "Mass Casualty",capacity: 4, equipmentSlots: 2, attributes: ["medicaltransport"],  cost: 25000, speed: 60 },
+  { class: "ambulance", type: "Inter-facility Transport", capacity: 2, equipmentSlots: 1, attributes: ["medicaltransport"], cost: 13000, speed: 65 },
 
-  { class: "sar", type: "Rescue",     capacity: 4, equipmentSlots: 4, attributes: [], cost: 15000 },
-  { class: "sar", type: "Support",    capacity: 2, equipmentSlots: 4, attributes: [], cost: 5000 },
-  { class: "sar", type: "Command",    capacity: 2, equipmentSlots: 3, attributes: [], cost: 15000 },
-  { class: "sar", type: "Off Road",   capacity: 2, equipmentSlots: 2, attributes: [], cost: 12000 }
+  { class: "police", type: "Patrol Car",      capacity: 2, equipmentSlots: 2, attributes: ["prisonerTransport"], cost: 9000,  speed: 85 },
+  { class: "police", type: "Unmarked Car",    capacity: 4, equipmentSlots: 2, attributes: [], cost: 9500,  speed: 85 },
+  { class: "police", type: "Special Services", capacity: 4, equipmentSlots: 4, attributes: [], cost: 20000, speed: 75 },
+  { class: "police", type: "SWAT Van",        capacity: 6, equipmentSlots: 4, attributes: ["armor","SWAT"], cost: 30000, speed: 65 },
+
+  { class: "sar", type: "Rescue",     capacity: 4, equipmentSlots: 4, attributes: [], cost: 15000, speed: 65 },
+  { class: "sar", type: "Support",    capacity: 2, equipmentSlots: 4, attributes: [], cost: 5000,  speed: 75 },
+  { class: "sar", type: "Command",    capacity: 2, equipmentSlots: 3, attributes: [], cost: 15000, speed: 65 },
+  { class: "sar", type: "Off Road",   capacity: 2, equipmentSlots: 2, attributes: [], cost: 12000, speed: 65 }
 ];
+
+unitTypes.forEach(u => {
+  if (typeof u.speed !== 'number') {
+    u.speed = CLASS_SPEED[u.class] || 63;
+  }
+});
+
 unitTypes.sort((a,b) => a.class.localeCompare(b.class) || a.type.localeCompare(b.type));
 if (typeof module !== 'undefined' && typeof module.exports !== 'undefined') {
   module.exports = unitTypes;


### PR DESCRIPTION
## Summary
- add explicit speed values for all unit types and class-level fallbacks
- use unit-type speeds on client with fallback to class defaults
- rename server travel speed mapping to class speed

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68babf77e05483288e463ff2e2956ff5