### PR TITLE
fix: remove duplicate CLASS_SPEED definition

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -259,7 +259,7 @@
 
 <script>
 // ========= constants / helpers =========
-const CLASS_SPEED = { fire: 63, police: 94, ambulance: 75, sar: 70 }; // km/h used across UI (25% faster)
+// CLASS_SPEED is provided by /config/unitTypes.js
 const TRAVEL_SPEED = unitTypes.reduce((acc, u) => {
   acc[u.type] = u.speed || CLASS_SPEED[u.class] || 63;
   return acc;


### PR DESCRIPTION
## Summary
- remove second CLASS_SPEED declaration to prevent redeclaration errors
- document that CLASS_SPEED comes from `/config/unitTypes.js`

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68bac275c6848328ba2dd31776ebb85b