### PR TITLE
Enable viewport and scrolling

### DIFF
--- a/public/cad.html
+++ b/public/cad.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>CAD Interface</title>
   <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" />
   <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>

--- a/public/style.css
+++ b/public/style.css
@@ -1,7 +1,7 @@
 html, body {
     height:100%;
     margin:0;
-    overflow:hidden;
+    overflow:auto;
 }
 
 body{


### PR DESCRIPTION
## Summary
- add responsive viewport meta tag to CAD page
- allow page scrolling by replacing hidden overflow on `html, body`

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68bf1c0fe4e4832897cf30955e564267