### PR TITLE
Increase touch target for CAD controls

### DIFF
--- a/public/style.css
+++ b/public/style.css
@@ -183,7 +183,9 @@ h3 {
 }
 
 .cad-speed {
-    padding:0.5em 1em;
+    padding:0.75em 1.25em;
+    min-width:44px;
+    min-height:44px;
     border:none;
     background:#333;
     color:#fff;
@@ -197,7 +199,9 @@ h3 {
 }
 
 .cad-action {
-    padding:0.5em 1em;
+    padding:0.75em 1.25em;
+    min-width:44px;
+    min-height:44px;
     border:none;
     background:#333;
     color:#fff;


### PR DESCRIPTION
## Summary
- add 44px minimum touch target for .cad-speed and .cad-action buttons
- bump padding for those buttons for clearer spacing

## Testing
- `npm test` *(fails: Error: no test specified)*
- `node -e "const puppeteer=require('puppeteer');(async()=>{const browser=await puppeteer.launch();const page=await browser.newPage();await page.goto('http://localhost:911/cad.html');await page.screenshot({path:'/tmp/cad.png'});await browser.close();})();"` *(fails: cannot open shared object file libatk-1.0.so.0)*

------
https://chatgpt.com/codex/tasks/task_e_68bf1faa8d808328841537e82d372280