### PR TITLE
Add responsive mobile layout for CAD interface

### DIFF
--- a/public/style.css
+++ b/public/style.css
@@ -239,3 +239,32 @@ h3 {
 .notification-error {
   background: #dc3545;
 }
+
+@media (max-width: 768px) {
+  #cadContent {
+    grid-template-columns: 1fr;
+    grid-template-rows: auto 50vh 1fr;
+  }
+
+  #cadMissions {
+    grid-row: 1;
+    grid-column: 1;
+    width: 100%;
+  }
+
+  #cadMap,
+  #cadDetail {
+    grid-row: 2;
+    grid-column: 1;
+    width: 100%;
+    height: 100%;
+  }
+
+  #cadStations,
+  #cadUnits {
+    grid-row: 3;
+    grid-column: 1;
+    width: 100%;
+    height: 100%;
+  }
+}


### PR DESCRIPTION
## Summary
- Add `@media (max-width: 768px)` to stack CAD sections vertically on small screens
- Ensure missions, map, and stations span full width with appropriate heights in mobile layout

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68bf22a42e9483289a00429149b950a7