### PR TITLE
Refactor CAD modals to use shared CSS class

### DIFF
--- a/public/cad.html
+++ b/public/cad.html
@@ -38,33 +38,21 @@
   </div>
 
   <!-- Edit Personnel Modal -->
-  <div id="editPersonnelModal" style="
-        position: fixed; top: 20%; left: 50%; transform: translateX(-50%);
-        background: white; border: 2px solid #444; padding: 1em;
-        width: 300px; box-shadow: 0 0 10px rgba(0,0,0,0.3);
-        display: none; z-index: 10001;">
+  <div id="editPersonnelModal" class="cad-modal">
         <h3>Edit Personnel</h3>
         <div id="editPersonnelContent">Loading...</div>
         <button onclick="document.getElementById('editPersonnelModal').style.display = 'none';">Close</button>
   </div>
 
   <!-- Edit Unit Modal -->
-  <div id="editUnitModal" style="
-        position: fixed; top: 20%; left: 50%; transform: translateX(-50%);
-        background: white; border: 2px solid #444; padding: 1em;
-        width: 300px; box-shadow: 0 0 10px rgba(0,0,0,0.3);
-        display: none; z-index: 10001;">
+  <div id="editUnitModal" class="cad-modal">
         <h3>Edit Unit</h3>
         <div id="editUnitContent">Loading...</div>
         <button onclick="document.getElementById('editUnitModal').style.display = 'none';">Close</button>
   </div>
 
   <!-- Unit Detail Modal -->
-  <div id="unitDetailModal" style="
-        position: fixed; top: 20%; left: 50%; transform: translateX(-50%);
-        background: white; border: 2px solid #444; padding: 1em;
-        width: 300px; box-shadow: 0 0 10px rgba(0,0,0,0.3);
-        display: none; z-index: 10001; max-height: 80vh; overflow-y: auto;">
+  <div id="unitDetailModal" class="cad-modal">
         <h3>Unit Details</h3>
         <div id="unitDetailContent">Loading...</div>
         <button onclick="document.getElementById('unitDetailModal').style.display = 'none';">Close</button>

--- a/public/style.css
+++ b/public/style.css
@@ -227,6 +227,23 @@ h3 {
     color:#e0e0e0;
 }
 
+.cad-modal {
+    position: fixed;
+    top: 20%;
+    left: 50%;
+    transform: translateX(-50%);
+    background: white;
+    border: 2px solid #444;
+    padding: 1em;
+    width: 90vw;
+    max-width: 400px;
+    box-shadow: 0 0 10px rgba(0,0,0,0.3);
+    display: none;
+    z-index: 10001;
+    max-height: 80vh;
+    overflow-y: auto;
+}
+
 /* Toast notifications */
 #notification-container {
   position: fixed;


### PR DESCRIPTION
## Summary
- Replace inline styles for CAD modals with reusable `.cad-modal` class
- Add responsive sizing and scrollable content for modals

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68bf24fdc1c48328b5cfe40167d24839