### PR TITLE
Persist patrol routes server-side for patrolling units

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -882,56 +882,26 @@ async function fetchMissions() {
 // ===== Patrol helpers =====
 const patrolStates = new Map();
 
-function randomPointNear(lat, lon, radiusKm) {
-  const r = radiusKm / 6371;
-  const u = Math.random();
-  const v = Math.random();
-  const w = r * Math.sqrt(u);
-  const t = 2 * Math.PI * v;
-  const lat1 = lat * Math.PI/180;
-  const lon1 = lon * Math.PI/180;
-  const newLat = Math.asin(Math.sin(lat1)*Math.cos(w) + Math.cos(lat1)*Math.sin(w)*Math.cos(t));
-  const newLon = lon1 + Math.atan2(Math.sin(t)*Math.sin(w)*Math.cos(lat1), Math.cos(w) - Math.sin(lat1)*Math.sin(newLat));
-  return [newLat*180/Math.PI, newLon*180/Math.PI];
-}
-
-async function patrolRoute(unitId, from, to, speedClassKmh, onDone) {
-  try {
-    const { coords, duration, annotations } = await fetchRouteOSRM(from, to);
-    const seg_durations = (annotations?.duration?.length === coords.length - 1)
-      ? annotations.duration
-      : Array.from({ length: coords.length - 1 }, () => duration / Math.max(1, coords.length - 1));
-    drawRoute(unitId, coords);
-    animateAlongRouteOffset(unitId, coords, seg_durations, onDone, 0);
-  } catch (err) {
-    const distKm = haversineKm(from[0], from[1], to[0], to[1]);
-    const etaSec = Math.max(5, Math.round((distKm / (speedClassKmh || 56)) * 3600));
-    animateMoveUnit(unitId, from, to, etaSec * 1000, onDone);
-  }
-}
-
-function startUnitPatrol(unit) {
+async function startUnitPatrol(unit) {
   if (!unit || patrolStates.has(unit.id)) return;
-  const st = _stationById.get(unit.station_id);
-  if (!st) return;
-  ensureUnitMarker(unit);
-  const speed = TRAVEL_SPEED[unit.type] || CLASS_SPEED[unit.class] || 63;
-  const state = { start: Date.now() };
-  patrolStates.set(unit.id, state);
-  const maxMs = 60 * 60 * 1000;
-
-  const step = (from) => {
-    const s = patrolStates.get(unit.id);
-    if (!s) return;
-    if (Date.now() - s.start >= maxMs) {
-      patrolRoute(unit.id, from, [st.lat, st.lon], speed, () => patrolStates.delete(unit.id));
+  patrolStates.set(unit.id, true);
+  const step = async () => {
+    let travel = null;
+    try {
+      const travels = await fetch('/api/unit-travel/active').then(r => r.json());
+      travel = travels.find(t => t.unit_id === unit.id);
+    } catch {}
+    if (!travel || travel.phase !== 'patrol') {
+      if (_unitById.get(unit.id)?.patrol) { setTimeout(step, 1000); }
+      else patrolStates.delete(unit.id);
       return;
     }
-    const dest = randomPointNear(st.lat, st.lon, 5);
-    patrolRoute(unit.id, from, dest, speed, () => step(dest));
+    ensureUnitMarker(unit);
+    const speed = TRAVEL_SPEED[unit.type] || CLASS_SPEED[unit.class] || 63;
+    routeAndAnimateUnit(unit.id, travel.from, travel.to, speed, step, { saved: travel, phase: 'patrol' });
+    patrolStates.set(unit.id, true);
   };
-
-  step([st.lat, st.lon]);
+  setTimeout(step, 200);
 }
 
 async function generateMissionAtPOI(poi) {
@@ -2121,7 +2091,13 @@ async function showUnitDetails(unitId) {
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ patrol: val })
     });
-    _unitById.set(unitId, { ...unit, patrol: val });
+    const updated = { ...unit, patrol: val };
+    _unitById.set(unitId, updated);
+    if (val) startUnitPatrol(updated);
+    else {
+      patrolStates.delete(unitId);
+      fetch(`/api/unit-travel/${unitId}`, { method: 'DELETE' }).catch(() => {});
+    }
   });
 
   const cancelBtn = content.querySelector('#cancel-mission-btn');
@@ -2900,6 +2876,10 @@ async function rebuildEnrouteMarkers() {
     for (const t of travels) {
       const u = _unitById.get(t.unit_id);
       if (!u) continue;
+      if (t.phase === 'patrol') {
+        startUnitPatrol(u);
+        continue;
+      }
       ensureUnitMarker(u);
       routeAndAnimateUnit(
           t.unit_id, t.from, t.to, TRAVEL_SPEED[u.type] || CLASS_SPEED[u.class] || 56,

--- a/services/patrol.js
+++ b/services/patrol.js
@@ -1,0 +1,75 @@
+const db = require('../db');
+
+const CLASS_SPEED = { fire: 63, police: 94, ambulance: 75, sar: 70 };
+
+function haversineKm(aLat, aLon, bLat, bLon) {
+  const R = 6371;
+  const dLat = (bLat - aLat) * Math.PI / 180;
+  const dLon = (bLon - aLon) * Math.PI / 180;
+  const la1 = aLat * Math.PI / 180, la2 = bLat * Math.PI / 180;
+  const h = Math.sin(dLat / 2) ** 2 + Math.cos(la1) * Math.cos(la2) * Math.sin(dLon / 2) ** 2;
+  return 2 * R * Math.asin(Math.sqrt(h));
+}
+
+function randomPointNear(lat, lon, radiusKm) {
+  const r = radiusKm / 6371;
+  const u = Math.random();
+  const v = Math.random();
+  const w = r * Math.sqrt(u);
+  const t = 2 * Math.PI * v;
+  const lat1 = lat * Math.PI / 180;
+  const lon1 = lon * Math.PI / 180;
+  const newLat = Math.asin(Math.sin(lat1) * Math.cos(w) + Math.cos(lat1) * Math.sin(w) * Math.cos(t));
+  const newLon = lon1 + Math.atan2(Math.sin(t) * Math.sin(w) * Math.cos(lat1), Math.cos(w) - Math.sin(lat1) * Math.sin(newLat));
+  return [newLat * 180 / Math.PI, newLon * 180 / Math.PI];
+}
+
+function startPatrol(unitId) {
+  return new Promise(resolve => {
+    db.get(`SELECT u.id, u.class, s.lat AS st_lat, s.lon AS st_lon FROM units u JOIN stations s ON s.id=u.station_id WHERE u.id=?`, [unitId], (err, row) => {
+      if (err || !row) return resolve();
+      const speed = CLASS_SPEED[row.class] || 56;
+      const [destLat, destLon] = randomPointNear(row.st_lat, row.st_lon, 5);
+      const fromLat = row.st_lat;
+      const fromLon = row.st_lon;
+      const distKm = haversineKm(fromLat, fromLon, destLat, destLon);
+      const total = Math.max(5, (distKm / speed) * 3600);
+      const coords = JSON.stringify([[fromLat, fromLon], [destLat, destLon]]);
+      const segs = JSON.stringify([total]);
+      db.run(`INSERT OR REPLACE INTO unit_travel (unit_id, mission_id, phase, started_at, from_lat, from_lon, to_lat, to_lon, coords, seg_durations, total_duration) VALUES (?, NULL, 'patrol', ?, ?, ?, ?, ?, ?, ?, ?)`,
+        [unitId, new Date().toISOString(), fromLat, fromLon, destLat, destLon, coords, segs, total], () => resolve());
+    });
+  });
+}
+
+function handlePatrolCompletion(travelRow) {
+  return new Promise(resolve => {
+    db.get(`SELECT u.class, u.patrol_until, s.lat AS st_lat, s.lon AS st_lon FROM units u JOIN stations s ON s.id=u.station_id WHERE u.id=?`, [travelRow.unit_id], (err, row) => {
+      if (err || !row) {
+        db.run('DELETE FROM unit_travel WHERE unit_id=?', [travelRow.unit_id], () => resolve());
+        return;
+      }
+      const speed = CLASS_SPEED[row.class] || 56;
+      const now = Date.now();
+      const fromLat = travelRow.to_lat;
+      const fromLon = travelRow.to_lon;
+      let destLat, destLon, phase = 'patrol';
+      if (row.patrol_until && now < row.patrol_until) {
+        [destLat, destLon] = randomPointNear(row.st_lat, row.st_lon, 5);
+      } else {
+        destLat = row.st_lat;
+        destLon = row.st_lon;
+        phase = 'return';
+        db.run('UPDATE units SET patrol=0, patrol_until=NULL WHERE id=?', [travelRow.unit_id]);
+      }
+      const distKm = haversineKm(fromLat, fromLon, destLat, destLon);
+      const total = Math.max(5, (distKm / speed) * 3600);
+      const coords = JSON.stringify([[fromLat, fromLon], [destLat, destLon]]);
+      const segs = JSON.stringify([total]);
+      db.run(`UPDATE unit_travel SET phase=?, started_at=?, from_lat=?, from_lon=?, to_lat=?, to_lon=?, coords=?, seg_durations=?, total_duration=? WHERE unit_id=?`,
+        [phase, new Date().toISOString(), fromLat, fromLon, destLat, destLon, coords, segs, total, travelRow.unit_id], () => resolve());
+    });
+  });
+}
+
+module.exports = { startPatrol, handlePatrolCompletion };


### PR DESCRIPTION
## Summary
- store patrol expiration on units and persist movements in new patrol service
- continue patrol legs on the server and resume them on reload
- add front-end hooks to animate server-managed patrol routes

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68c1c8cb7a488328ba38891a00147861