### PR TITLE
Fix straight-line fallback longitude delta

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -712,7 +712,8 @@ async function routeAndAnimateUnit(unitId, from, to, speedClassKmh, onArrive, re
   } catch (err) {
     console.warn('OSRM route failed; straight-line fallback:', err);
     const R = 6371;
-    const dLat = (to[0]-from[0]) * Math.PI/180, dLon = (to[1]-to[0]) * Math.PI/180;
+    const dLat = (to[0]-from[0]) * Math.PI/180;
+    const dLon = (to[1]-from[1]) * Math.PI/180;
     const la1 = from[0] * Math.PI/180, la2 = to[0] * Math.PI/180;
     const h = Math.sin(dLat/2)**2 + Math.cos(la1)*Math.cos(la2)*Math.sin(dLon/2)**2;
     const distKm = 2*R*Math.asin(Math.sqrt(h));


### PR DESCRIPTION
## Summary
- fix the straight-line fallback distance math by subtracting the origin longitude from the destination longitude
- ensure the computed fallback route duration reflects the true great-circle distance so units no longer get stuck enroute when routing fails

## Testing
- not run (not available)

------
https://chatgpt.com/codex/tasks/task_e_68ccb39d947883289eeea22e9ba7629e