### PR TITLE
Refactor mission resolution into shared service

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ node_modules/
 public/images/
 *.db
 game.db
+*.sqlite
 *.db
 *.db
 game.db

--- a/db.js
+++ b/db.js
@@ -1,4 +1,6 @@
 const sqlite3 = require("sqlite3").verbose();
-const db = new sqlite3.Database("./game.db");
+
+const dbPath = process.env.DB_PATH || process.env.SQLITE_DB_PATH || "./game.db";
+const db = new sqlite3.Database(dbPath);
 
 module.exports = db;

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "main": "server.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1",
+    "test": "node --test",
     "start": "nodemon server.js"
   },
   "keywords": [],

--- a/public/index.html
+++ b/public/index.html
@@ -2817,7 +2817,7 @@ function setupTimerForMission(mission, endTime) {
     activeWorkTimers.delete(mission.id);
     persistWorkTimers();
     const assignedBefore = await (await fetch(`/api/missions/${mission.id}/units`)).json();
-    await fetch(`/api/missions/${mission.id}/resolve`, { method:'POST' });
+    await fetch(`/api/missions/${mission.id}`, { method:'PUT' });
     if (!_stationById || _stationById.size===0) {
       const stations = await (await fetch('/api/stations')).json();
       cacheStations(stations);

--- a/services/missions.js
+++ b/services/missions.js
@@ -1,0 +1,187 @@
+const db = require('../db');
+const unitTypes = require('../unitTypes');
+const { adjustBalance, getBalance } = require('../wallet');
+const { clearMissionClock } = require('./missionTimers');
+
+const CLASS_SPEED = { fire: 63, police: 94, ambulance: 75, sar: 70 };
+
+function run(sql, params = []) {
+  return new Promise((resolve, reject) => {
+    db.run(sql, params, function (err) {
+      if (err) return reject(err);
+      resolve(this);
+    });
+  });
+}
+
+function get(sql, params = []) {
+  return new Promise((resolve, reject) => {
+    db.get(sql, params, (err, row) => (err ? reject(err) : resolve(row)));
+  });
+}
+
+function all(sql, params = []) {
+  return new Promise((resolve, reject) => {
+    db.all(sql, params, (err, rows) => (err ? reject(err) : resolve(rows || [])));
+  });
+}
+
+function getFacilityOccupancy(stationId, type) {
+  return new Promise((resolve, reject) => {
+    const now = Date.now();
+    db.get(
+      `SELECT COUNT(*) AS cnt, MIN(expires_at) AS next FROM facility_load WHERE station_id=? AND type=? AND expires_at>?`,
+      [stationId, type, now],
+      (err, row) => {
+        if (err) return reject(err);
+        resolve({ count: row?.cnt || 0, nextFree: row?.next || 0 });
+      }
+    );
+  });
+}
+
+function addFacilityLoad(stationId, type, expiresAt) {
+  return run(
+    `INSERT INTO facility_load (station_id, type, expires_at) VALUES (?,?,?)`,
+    [stationId, type, expiresAt]
+  );
+}
+
+async function allocateTransport(kind, lat, lon, unitClass) {
+  const facilities = await all(
+    kind === 'patient'
+      ? `SELECT id, lat, lon, bed_capacity AS capacity FROM stations WHERE type='hospital' AND bed_capacity>0`
+      : `SELECT id, lat, lon, holding_cells AS capacity FROM stations WHERE (type='jail' OR (type='police' AND holding_cells>0))`
+  );
+  if (!facilities.length) return null;
+
+  facilities.forEach(f => {
+    f.distance = haversine(lat, lon, f.lat, f.lon);
+  });
+  facilities.sort((a, b) => a.distance - b.distance);
+
+  const speed = CLASS_SPEED[unitClass] || 63;
+  const now = Date.now();
+
+  for (let i = 0; i < facilities.length; i++) {
+    const f = facilities[i];
+    const occ = await getFacilityOccupancy(f.id, kind);
+    if (occ.count < f.capacity) {
+      await addFacilityLoad(f.id, kind, now + 10 * 60 * 1000);
+      return f.id;
+    }
+    const nextFree = occ.nextFree || now;
+    const timeUntilFree = nextFree - now;
+    const next = facilities[i + 1];
+    const travelToNext = next ? (haversine(lat, lon, next.lat, next.lon) / speed) * 3600 * 1000 : Infinity;
+    if (timeUntilFree < travelToNext) {
+      await addFacilityLoad(f.id, kind, nextFree + 10 * 60 * 1000);
+      return f.id;
+    }
+  }
+
+  const first = facilities[0];
+  const occ = await getFacilityOccupancy(first.id, kind);
+  const expiry = (occ.nextFree || now) + 10 * 60 * 1000;
+  await addFacilityLoad(first.id, kind, expiry);
+  return first.id;
+}
+
+async function handleTransports(unitIds, lat, lon, patients, prisoners) {
+  let patientCount = 0;
+  for (const p of patients) patientCount += Number(p.count || 0);
+  let prisonerCount = 0;
+  for (const p of prisoners) prisonerCount += Number(p.transport || 0);
+  if (!unitIds.length || (patientCount === 0 && prisonerCount === 0)) return;
+
+  const placeholders = unitIds.map(() => '?').join(',');
+  const rows = await all(`SELECT id, type FROM units WHERE id IN (${placeholders})`, unitIds);
+
+  const medUnits = [];
+  const prisUnits = [];
+  for (const r of rows) {
+    const ut = unitTypes.find(t => t.type === r.type);
+    const attrs = Array.isArray(ut?.attributes) ? ut.attributes : [];
+    if (attrs.includes('medicaltransport')) medUnits.push(r.id);
+    if (attrs.includes('prisonertransport')) prisUnits.push(r.id);
+  }
+
+  const medTransports = Math.min(patientCount, medUnits.length);
+  for (let i = 0; i < medTransports; i++) {
+    await allocateTransport('patient', lat, lon, 'ambulance');
+    await adjustBalance(500);
+  }
+
+  const prisTransports = Math.min(prisonerCount, prisUnits.length);
+  for (let i = 0; i < prisTransports; i++) {
+    await allocateTransport('prisoner', lat, lon, 'police');
+    await adjustBalance(500);
+  }
+}
+
+function haversine(aLat, aLon, bLat, bLon) {
+  const R = 6371;
+  const dLat = (bLat - aLat) * Math.PI / 180;
+  const dLon = (bLon - aLon) * Math.PI / 180;
+  const la1 = aLat * Math.PI / 180, la2 = bLat * Math.PI / 180;
+  const h = Math.sin(dLat / 2) ** 2 + Math.cos(la1) * Math.cos(la2) * Math.sin(dLon / 2) ** 2;
+  return 2 * R * Math.asin(Math.sqrt(h));
+}
+
+function safeParse(json, fallback) {
+  try {
+    const parsed = JSON.parse(json);
+    return Array.isArray(parsed) ? parsed : fallback;
+  } catch {
+    return fallback;
+  }
+}
+
+function resolveMissionById(missionId, cb) {
+  const promise = (async () => {
+    await run('UPDATE missions SET status=? WHERE id=?', ['resolved', missionId]);
+
+    const unitRows = await all('SELECT unit_id FROM mission_units WHERE mission_id=?', [missionId]);
+    const ids = unitRows.map(r => r.unit_id);
+    if (ids.length) {
+      const placeholders = ids.map(() => '?').join(',');
+      await run(`UPDATE units SET status='available', responding=0 WHERE id IN (${placeholders})`, ids);
+      await run(`DELETE FROM unit_travel WHERE unit_id IN (${placeholders})`, ids);
+    }
+    await run('DELETE FROM mission_units WHERE mission_id=?', [missionId]);
+
+    const mission = await get('SELECT type, lat, lon, patients, prisoners, penalties FROM missions WHERE id=?', [missionId]);
+    const missionName = mission?.type || '';
+    const patients = safeParse(mission?.patients, []);
+    const prisoners = safeParse(mission?.prisoners, []);
+    const penalties = safeParse(mission?.penalties, []);
+
+    const template = await get('SELECT rewards FROM mission_templates WHERE name=?', [missionName]);
+    const baseReward = Number(template?.rewards || 0);
+    const rewardPenalty = penalties.reduce((sum, p) => sum + (Number(p.rewardPenalty) || 0), 0);
+    const reward = Math.max(0, baseReward * (1 - rewardPenalty / 100));
+
+    if (reward > 0) {
+      await adjustBalance(+reward);
+    }
+
+    if (mission) {
+      await handleTransports(ids, mission.lat, mission.lon, patients, prisoners);
+    }
+
+    const balance = await getBalance();
+    clearMissionClock(missionId);
+
+    return { freed: ids.length, reward, balance };
+  })();
+
+  if (typeof cb === 'function') {
+    promise.then(result => cb(null, result)).catch(err => cb(err));
+  }
+  return promise;
+}
+
+module.exports = {
+  resolveMissionById,
+  getFacilityOccupancy,
+};

--- a/test/missions.test.js
+++ b/test/missions.test.js
@@ -1,0 +1,191 @@
+const path = require('node:path');
+const fs = require('node:fs');
+const { test, beforeEach, after } = require('node:test');
+const assert = require('node:assert');
+
+const dbPath = path.join(__dirname, 'test.sqlite');
+if (fs.existsSync(dbPath)) fs.unlinkSync(dbPath);
+process.env.DB_PATH = dbPath;
+
+const db = require('../db');
+const missionsController = require('../controllers/missionsController');
+const { missionClocks } = require('../services/missionTimers');
+
+function exec(sql) {
+  return new Promise((resolve, reject) => {
+    db.exec(sql, err => (err ? reject(err) : resolve()));
+  });
+}
+
+function run(sql, params = []) {
+  return new Promise((resolve, reject) => {
+    db.run(sql, params, function (err) {
+      if (err) return reject(err);
+      resolve(this);
+    });
+  });
+}
+
+function all(sql, params = []) {
+  return new Promise((resolve, reject) => {
+    db.all(sql, params, (err, rows) => (err ? reject(err) : resolve(rows || [])));
+  });
+}
+
+function get(sql, params = []) {
+  return new Promise((resolve, reject) => {
+    db.get(sql, params, (err, row) => (err ? reject(err) : resolve(row)));
+  });
+}
+
+function createMockRes() {
+  return {
+    statusCode: 200,
+    body: undefined,
+    status(code) {
+      this.statusCode = code;
+      return this;
+    },
+    json(payload) {
+      this.body = payload;
+      return this;
+    },
+  };
+}
+
+beforeEach(async () => {
+  missionClocks.clear();
+  await exec(`
+    DROP TABLE IF EXISTS mission_units;
+    DROP TABLE IF EXISTS unit_travel;
+    DROP TABLE IF EXISTS missions;
+    DROP TABLE IF EXISTS mission_templates;
+    DROP TABLE IF EXISTS units;
+    DROP TABLE IF EXISTS wallet;
+    DROP TABLE IF EXISTS facility_load;
+    DROP TABLE IF EXISTS stations;
+
+    CREATE TABLE missions (
+      id INTEGER PRIMARY KEY,
+      type TEXT,
+      status TEXT,
+      lat REAL,
+      lon REAL,
+      patients TEXT,
+      prisoners TEXT,
+      penalties TEXT,
+      resolve_at INTEGER
+    );
+
+    CREATE TABLE mission_units (
+      mission_id INTEGER,
+      unit_id INTEGER
+    );
+
+    CREATE TABLE unit_travel (
+      unit_id INTEGER,
+      mission_id INTEGER
+    );
+
+    CREATE TABLE mission_templates (
+      name TEXT PRIMARY KEY,
+      rewards INTEGER
+    );
+
+    CREATE TABLE units (
+      id INTEGER PRIMARY KEY,
+      type TEXT,
+      status TEXT,
+      responding INTEGER
+    );
+
+    CREATE TABLE wallet (
+      id INTEGER PRIMARY KEY,
+      balance INTEGER
+    );
+
+    CREATE TABLE facility_load (
+      station_id INTEGER,
+      type TEXT,
+      expires_at INTEGER
+    );
+
+    CREATE TABLE stations (
+      id INTEGER PRIMARY KEY,
+      lat REAL,
+      lon REAL,
+      bed_capacity INTEGER,
+      holding_cells INTEGER,
+      type TEXT
+    );
+  `);
+});
+
+after(async () => {
+  await new Promise(resolve => db.close(() => resolve()));
+});
+
+test('PUT /api/missions/:id resolves missions and releases resources', async () => {
+  const missionId = 1;
+  const now = Date.now();
+
+  await run(`INSERT INTO missions (id, type, status, lat, lon, patients, prisoners, penalties, resolve_at) VALUES (?,?,?,?,?,?,?,?,?)`, [
+    missionId,
+    'Test Mission',
+    'active',
+    40.0,
+    -75.0,
+    JSON.stringify([]),
+    JSON.stringify([]),
+    JSON.stringify([]),
+    now + 60000,
+  ]);
+
+  await run(`INSERT INTO mission_templates (name, rewards) VALUES (?, ?)`, ['Test Mission', 1000]);
+
+  await run(`INSERT INTO units (id, type, status, responding) VALUES (?,?,?,?)`, [101, 'Ambulance', 'on_scene', 1]);
+  await run(`INSERT INTO units (id, type, status, responding) VALUES (?,?,?,?)`, [102, 'Patrol Car', 'on_scene', 1]);
+
+  await run(`INSERT INTO mission_units (mission_id, unit_id) VALUES (?, ?)`, [missionId, 101]);
+  await run(`INSERT INTO mission_units (mission_id, unit_id) VALUES (?, ?)`, [missionId, 102]);
+
+  await run(`INSERT INTO unit_travel (unit_id, mission_id) VALUES (?, ?)`, [101, missionId]);
+  await run(`INSERT INTO unit_travel (unit_id, mission_id) VALUES (?, ?)`, [102, missionId]);
+
+  await run(`INSERT INTO wallet (id, balance) VALUES (1, ?)`, [500]);
+
+  missionClocks.set(missionId, {
+    endAt: now + 60000,
+    startedAt: now,
+    baseDuration: 60000,
+  });
+
+  const req = { params: { id: String(missionId) } };
+  const res = createMockRes();
+
+  await missionsController.updateMission(req, res);
+
+  assert.equal(res.statusCode, 200);
+  assert.ok(res.body?.ok, 'response should include ok flag');
+  assert.equal(res.body?.freed, 2);
+  assert.equal(res.body?.reward, 1000);
+  assert.equal(res.body?.balance, 1500);
+
+  const unitRows = await all(`SELECT status, responding FROM units ORDER BY id`);
+  for (const row of unitRows) {
+    assert.equal(row.status, 'available');
+    assert.equal(row.responding, 0);
+  }
+
+  const remainingAssignments = await all(`SELECT * FROM mission_units WHERE mission_id=?`, [missionId]);
+  assert.equal(remainingAssignments.length, 0);
+
+  const remainingTravel = await all(`SELECT * FROM unit_travel WHERE mission_id=?`, [missionId]);
+  assert.equal(remainingTravel.length, 0);
+
+  const missionRow = await get(`SELECT status, resolve_at FROM missions WHERE id=?`, [missionId]);
+  assert.equal(missionRow.status, 'resolved');
+  assert.strictEqual(missionRow.resolve_at, null);
+
+  assert.equal(missionClocks.has(missionId), false);
+});


### PR DESCRIPTION
## Summary
- extract the mission resolution workflow into services/missions so both the legacy server and modular controller reuse the same cleanup logic
- update the modular PUT /api/missions/:id handler and UI auto-resolve call to invoke the shared resolver and return the legacy payload
- allow overriding the SQLite database path for tests and add a node-based regression test that verifies resolving a mission frees resources and updates the wallet

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d8c49df7ec832898bb70b09826a3d5