### PR TITLE
Auto-populate random names for new station personnel

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -2414,8 +2414,23 @@ function openStationBuilderModal(initial = {}) {
       updateCostSummary();
     });
 
-    addPersonBtn.addEventListener('click', () => {
-      state.personnel.push({ name: '', training: [], assignedUnit: null });
+    async function fetchRandomPersonName() {
+      try {
+        const rnd = await fetch('/api/random-name').then(r => r.json());
+        if (rnd?.first && rnd?.last) {
+          return `${rnd.first} ${rnd.last}`;
+        }
+      } catch {
+        // ignore failures and fall back to empty string
+      }
+      return '';
+    }
+
+    addPersonBtn.addEventListener('click', async () => {
+      const person = { name: '', training: [], assignedUnit: null };
+      const randomName = await fetchRandomPersonName();
+      if (randomName) person.name = randomName;
+      state.personnel.push(person);
       renderPersonnel();
       updateCostSummary();
     });


### PR DESCRIPTION
## Summary
- fetch a random name from the existing /api/random-name endpoint when adding personnel in the station builder
- default the new person's name to the fetched value so the new-station UI mirrors the regular station view behavior

## Testing
- not run (UI-only change)


------
https://chatgpt.com/codex/tasks/task_e_68d8def0683c8328bf3cedb7c2eef7f5