### PR TITLE
Add map address search with Nominatim lookup

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -18,7 +18,53 @@
                 html, body { height: 100%; margin: 0; overflow: hidden; }
                 body { display: flex; height: 100vh; font-family: sans-serif; }
                 #sidebar { max-width: 30%; width: 100%; overflow-y: auto; padding: 10px; box-sizing: border-box; }
-                #map { flex: 1; }
+                #map { flex: 1; position: relative; }
+                .map-search {
+                        position: absolute;
+                        top: 10px;
+                        left: 50%;
+                        transform: translateX(-50%);
+                        display: flex;
+                        gap: 0.5em;
+                        align-items: center;
+                        background: rgba(255, 255, 255, 0.95);
+                        padding: 0.5em 0.75em;
+                        border-radius: 6px;
+                        box-shadow: 0 2px 6px rgba(0, 0, 0, 0.2);
+                        z-index: 1000;
+                }
+                .map-search input[type="text"] {
+                        min-width: 220px;
+                        padding: 0.35em 0.5em;
+                        border: 1px solid #ccc;
+                        border-radius: 4px;
+                }
+                .map-search button {
+                        padding: 0.35em 0.75em;
+                        border: none;
+                        border-radius: 4px;
+                        background: #007bff;
+                        color: #fff;
+                        cursor: pointer;
+                }
+                .map-search-status {
+                        position: absolute;
+                        top: 62px;
+                        left: 50%;
+                        transform: translateX(-50%);
+                        background: rgba(0, 0, 0, 0.7);
+                        color: #fff;
+                        padding: 0.35em 0.75em;
+                        border-radius: 4px;
+                        box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
+                        z-index: 999;
+                        max-width: 80%;
+                        text-align: center;
+                        pointer-events: none;
+                }
+                .map-search-status:empty {
+                        display: none;
+                }
 		.mission { border-bottom: 1px solid #ccc; margin-bottom: 1em; padding-bottom: 0.5em; }
                 .tab-button { padding: 0.5em 1em; border: none; background: #ddd; cursor: pointer; }
                 .tab-button.active { background: #aaa; font-weight: bold; }
@@ -157,7 +203,13 @@
         </div>
 </div>
 
-<div id="map"></div>
+<div id="map">
+        <form id="addressSearchForm" class="map-search">
+                <input type="text" id="addressSearchInput" placeholder="Search address..." />
+                <button type="submit">Search</button>
+        </form>
+        <div id="addressSearchStatus" class="map-search-status"></div>
+</div>
 
 <!-- Modal for Mission & Station Details -->
 <div id="missionDetails" style="
@@ -425,6 +477,62 @@ let buildStationMode = false;
 
 const map = L.map("map").setView([47.5646, -52.7002], 13);
 L.tileLayer("https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png", { attribution: "&copy; OpenStreetMap contributors" }).addTo(map);
+
+const addressSearchForm = document.getElementById('addressSearchForm');
+const addressSearchInput = document.getElementById('addressSearchInput');
+const addressSearchStatus = document.getElementById('addressSearchStatus');
+let addressSearchMarker = null;
+
+addressSearchForm?.addEventListener('submit', async (event) => {
+  event.preventDefault();
+  if (!addressSearchInput || !addressSearchStatus) return;
+  const query = addressSearchInput.value.trim();
+  if (!query) {
+    addressSearchStatus.textContent = 'Please enter an address to search.';
+    return;
+  }
+
+  addressSearchStatus.textContent = `Searching for "${query}"...`;
+
+  try {
+    const url = `https://nominatim.openstreetmap.org/search?format=json&q=${encodeURIComponent(query)}&limit=1&addressdetails=1`;
+    const response = await fetch(url, {
+      headers: {
+        'Accept': 'application/json'
+      }
+    });
+    if (!response.ok) {
+      throw new Error(`Lookup failed with status ${response.status}`);
+    }
+    const data = await response.json();
+    if (!Array.isArray(data) || data.length === 0) {
+      addressSearchStatus.textContent = `No results found for "${query}".`;
+      return;
+    }
+
+    const result = data[0];
+    const lat = parseFloat(result.lat);
+    const lon = parseFloat(result.lon);
+    if (Number.isNaN(lat) || Number.isNaN(lon)) {
+      throw new Error('Received invalid coordinates from geocoder.');
+    }
+
+    const zoom = 16;
+    map.setView([lat, lon], zoom);
+    if (addressSearchMarker) {
+      map.removeLayer(addressSearchMarker);
+    }
+    addressSearchMarker = L.marker([lat, lon]);
+    addressSearchMarker.addTo(map);
+    if (result.display_name) {
+      addressSearchMarker.bindPopup(result.display_name).openPopup();
+    }
+    addressSearchStatus.textContent = result.display_name ? `Located: ${result.display_name}` : 'Location found.';
+  } catch (error) {
+    console.error('Address lookup failed', error);
+    addressSearchStatus.textContent = `Error searching address: ${error.message || error}`;
+  }
+});
 
 const zoneLayerGroup = L.featureGroup();
 const zoneLayers = new Map();


### PR DESCRIPTION
## Summary
- add a styled search overlay and status display to the map
- wrap the map element with an address search form
- integrate a Nominatim lookup to recenter the map and drop a marker for results

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e0720ac7d88328815d435991123a5a