### PR TITLE
Add station rename and delete actions

### DIFF
--- a/routes/stations.js
+++ b/routes/stations.js
@@ -11,6 +11,8 @@ router.patch('/:id/holding-cells', stations.patchHoldingCells);
 router.patch('/:id/equipment-slots', stations.patchEquipmentSlots);
 router.patch('/:id/department', stations.patchDepartment);
 router.patch('/:id/icon', stations.patchIcon);
+router.patch('/:id/name', stations.patchName);
+router.delete('/:id', stations.deleteStation);
 router.delete('/', stations.deleteStations);
 router.post('/:id/equipment', stations.buyEquipment);
 


### PR DESCRIPTION
## Summary
- add REST endpoints to rename a station or remove a single station with cascading cleanup
- expose edit and delete station actions in the CAD UI, including prompts and confirmation

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e07fdfaf148328ba39a3d63a44d5b7