### PR TITLE
Add clear button to map search

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -39,13 +39,32 @@
                         border: 1px solid #ccc;
                         border-radius: 4px;
                 }
-                .map-search button {
+                .map-search button[type="submit"] {
                         padding: 0.35em 0.75em;
                         border: none;
                         border-radius: 4px;
                         background: #007bff;
                         color: #fff;
                         cursor: pointer;
+                }
+                .map-search__clear {
+                        background: none;
+                        color: #555;
+                        border: 1px solid transparent;
+                        border-radius: 50%;
+                        width: 28px;
+                        height: 28px;
+                        display: inline-flex;
+                        align-items: center;
+                        justify-content: center;
+                        font-size: 1rem;
+                        line-height: 1;
+                }
+                .map-search__clear:hover,
+                .map-search__clear:focus {
+                        border-color: #ccc;
+                        background: rgba(0,0,0,0.05);
+                        outline: none;
                 }
                 .map-search-status {
                         position: absolute;
@@ -207,6 +226,7 @@
         <form id="addressSearchForm" class="map-search">
                 <input type="text" id="addressSearchInput" placeholder="Search address..." />
                 <button type="submit">Search</button>
+                <button type="button" id="addressSearchClear" aria-label="Clear search" title="Clear search" class="map-search__clear">✕</button>
         </form>
         <div id="addressSearchStatus" class="map-search-status"></div>
 </div>
@@ -481,6 +501,7 @@ L.tileLayer("https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png", { attribution:
 const addressSearchForm = document.getElementById('addressSearchForm');
 const addressSearchInput = document.getElementById('addressSearchInput');
 const addressSearchStatus = document.getElementById('addressSearchStatus');
+const addressSearchClearButton = document.getElementById('addressSearchClear');
 let addressSearchMarker = null;
 
 addressSearchForm?.addEventListener('submit', async (event) => {
@@ -531,6 +552,17 @@ addressSearchForm?.addEventListener('submit', async (event) => {
   } catch (error) {
     console.error('Address lookup failed', error);
     addressSearchStatus.textContent = `Error searching address: ${error.message || error}`;
+  }
+});
+
+addressSearchClearButton?.addEventListener('click', () => {
+  if (!addressSearchInput || !addressSearchStatus) return;
+  addressSearchInput.value = '';
+  addressSearchInput.focus();
+  addressSearchStatus.textContent = '';
+  if (addressSearchMarker) {
+    map.removeLayer(addressSearchMarker);
+    addressSearchMarker = null;
   }
 });
 


### PR DESCRIPTION
## Summary
- add a clear button to the map search form so users can remove search text and pin
- style the clear button to fit within the search controls
- clear the map marker and status text when the new control is used

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e0837e1468832882f9405d9031a53c