### PR TITLE
Add shared currency formatting helper

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -187,7 +187,7 @@
                 function setWalletBalanceDisplay(balance){
                   const el = document.getElementById('walletDisplay');
                   if (!el) return;
-                  el.textContent = `Balance: $${balance}`;
+                  el.textContent = `Balance: ${formatCurrency(balance)}`;
                 }
 
                 async function refreshWallet(){

--- a/public/js/cad.js
+++ b/public/js/cad.js
@@ -1,4 +1,4 @@
-import { fetchNoCache, formatTime, playSound, formatStatus } from './common.js';
+import { fetchNoCache, formatTime, playSound, formatStatus, formatCurrency } from './common.js';
 import { getMissions, renderMissionRow } from './missions.js';
 import { getStations, renderStationList } from './stations.js';
 import { editUnit, editPersonnel } from './edit-dialogs.js';
@@ -225,7 +225,7 @@ async function init() {
 async function updateWallet() {
   try {
     const w = await fetchNoCache('/api/wallet').then(r=>r.json());
-    document.getElementById('walletDisplay').textContent = `Balance: $${w.balance}`;
+    document.getElementById('walletDisplay').textContent = `Balance: ${formatCurrency(w.balance)}`;
   } catch {}
 }
 

--- a/public/js/common.js
+++ b/public/js/common.js
@@ -26,6 +26,12 @@ export function formatTime(seconds) {
   return `${m}:${sec.toString().padStart(2, '0')}`;
 }
 
+// Helper to format numeric values as USD currency strings
+export function formatCurrency(amount) {
+  return new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD' })
+    .format(Number(amount) || 0);
+}
+
 // Map internal unit statuses to human readable status codes
 export function formatStatus(status, responding = false) {
   switch (status) {
@@ -116,6 +122,7 @@ export function showConfirmModal(message) {
 window.fetchNoCache = fetchNoCache;
 window.haversineKm = haversineKm;
 window.formatTime = formatTime;
+window.formatCurrency = formatCurrency;
 window.formatStatus = formatStatus;
 window.playSound = playSound;
 window.showConfirmModal = showConfirmModal;


### PR DESCRIPTION
## Summary
- add a shared `formatCurrency` helper in the common frontend utilities and expose it for legacy scripts
- update wallet balance displays in the index page and CAD view to use the currency helper

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e20b05eadc8328b4f493fe7bf55458