### PR TITLE
Fix redeclaration error in mobile pickUnitIconUrl

### DIFF
--- a/public/js/mobile.js
+++ b/public/js/mobile.js
@@ -636,16 +636,6 @@ function createAssignedChip(unit) {
   const status = formatStatus(unit.status || 'enroute', unit.responding);
   return createChip(`${label} • ${status}`, 'unit');
 }
-function pickUnitIconUrl(unit) {
-  if (!unit) return null;
-  const sanitizedType = (unit.type || '').replace(/\s+/g, '');
-  const baseIcon = sanitizedType ? `/images/${sanitizedType}.png` : null;
-  const respDefault = sanitizedType ? `/images/${sanitizedType}-responding.png` : null;
-  const normal = unit.icon || baseIcon || stationIcons[unit.class] || stationIcons.fire;
-  const responding = unit.responding_icon || respDefault || normal;
-  return unit.responding ? responding : normal;
-}
-
 function buildMissionDetail(mission) {
   const assigned = missionAssignments.get(mission.id) || [];
   const detail = document.createElement('div');


### PR DESCRIPTION
## Summary
- remove the duplicate pickUnitIconUrl definition in the mobile front-end script to prevent redeclaration errors when loading the page

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e21571c6748328a858141db69e3581