### PR TITLE
Refine mobile mission dispatch workflows

### DIFF
--- a/public/mobile.html
+++ b/public/mobile.html
@@ -263,6 +263,134 @@
       gap: 12px;
     }
 
+    .dispatch-button-grid {
+      display: grid;
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+      gap: 12px;
+    }
+
+    .dispatch-button {
+      border: none;
+      border-radius: 12px;
+      padding: 12px;
+      font-weight: 600;
+      font-size: 0.95rem;
+      background: #1d4ed8;
+      color: #ffffff;
+      box-shadow: 0 8px 16px rgba(29, 78, 216, 0.25);
+      cursor: pointer;
+      transition: transform 0.15s ease, box-shadow 0.15s ease, background 0.15s ease;
+    }
+
+    .dispatch-button:hover:not(:disabled) {
+      background: #1e40af;
+      transform: translateY(-1px);
+      box-shadow: 0 12px 20px rgba(29, 78, 216, 0.2);
+    }
+
+    .dispatch-button:disabled {
+      opacity: 0.6;
+      cursor: not-allowed;
+      box-shadow: none;
+      transform: none;
+    }
+
+    .dispatch-button.active {
+      outline: 2px solid #38bdf8;
+      outline-offset: 2px;
+    }
+
+    .dispatch-button--primary {
+      width: 100%;
+    }
+
+    .dispatch-status {
+      min-height: 1.2em;
+      font-size: 0.85rem;
+      color: #475569;
+    }
+
+    .dispatch-status[data-tone='success'] {
+      color: #15803d;
+    }
+
+    .dispatch-status[data-tone='error'] {
+      color: #b91c1c;
+    }
+
+    .dispatch-status[data-tone='info'] {
+      color: #0f172a;
+    }
+
+    .dispatch-panel-container.hidden {
+      display: none;
+    }
+
+    .dispatch-panel-container {
+      margin-top: 12px;
+    }
+
+    .dispatch-panel {
+      display: flex;
+      flex-direction: column;
+      gap: 12px;
+      padding: 12px;
+      border-radius: 12px;
+      background: #f8fafc;
+      border: 1px solid #e2e8f0;
+      box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.6);
+    }
+
+    .dispatch-panel__intro {
+      margin: 0;
+      font-size: 0.85rem;
+      color: #475569;
+    }
+
+    .dispatch-panel__list {
+      display: flex;
+      flex-direction: column;
+      gap: 12px;
+      max-height: 280px;
+      overflow-y: auto;
+      padding-right: 4px;
+    }
+
+    .dispatch-panel__loading,
+    .dispatch-panel__empty,
+    .dispatch-panel__error {
+      font-size: 0.85rem;
+      text-align: center;
+      padding: 16px 8px;
+    }
+
+    .dispatch-panel__loading {
+      color: #1d4ed8;
+    }
+
+    .dispatch-panel__empty {
+      color: #64748b;
+    }
+
+    .dispatch-panel__error {
+      color: #b91c1c;
+    }
+
+    .dispatch-panel__actions {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 12px;
+      align-items: center;
+    }
+
+    .dispatch-panel__force {
+      display: inline-flex;
+      align-items: center;
+      gap: 6px;
+      font-size: 0.85rem;
+      color: #1f2937;
+    }
+
     .dispatch-group {
       background: rgba(148, 163, 184, 0.12);
       border-radius: 12px;
@@ -297,8 +425,8 @@
 
     .dispatch-unit {
       display: inline-flex;
-      align-items: center;
-      gap: 6px;
+      align-items: flex-start;
+      gap: 8px;
       padding: 6px 10px;
       border-radius: 10px;
       background: #ffffff;
@@ -310,6 +438,55 @@
       accent-color: #1d4ed8;
       width: 16px;
       height: 16px;
+    }
+
+    .dispatch-unit__text {
+      display: flex;
+      flex-direction: column;
+      gap: 2px;
+    }
+
+    .dispatch-unit__name {
+      font-weight: 600;
+      color: #0f172a;
+    }
+
+    .dispatch-unit__meta {
+      font-size: 0.75rem;
+      color: #64748b;
+    }
+
+    .dispatch-type-row {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 12px;
+      padding: 10px 12px;
+      border-radius: 12px;
+      background: #ffffff;
+      box-shadow: 0 4px 12px rgba(15, 23, 42, 0.08);
+    }
+
+    .dispatch-type-label {
+      font-weight: 600;
+      color: #1f2937;
+      font-size: 0.9rem;
+    }
+
+    .dispatch-type-button {
+      border: none;
+      border-radius: 999px;
+      background: #0f172a;
+      color: #ffffff;
+      font-size: 0.85rem;
+      font-weight: 600;
+      padding: 6px 12px;
+      cursor: pointer;
+    }
+
+    .dispatch-type-button:disabled {
+      opacity: 0.6;
+      cursor: not-allowed;
     }
 
     .dispatch-actions {


### PR DESCRIPTION
## Summary
- keep the mission detail modal anchored by moving the close control to the top and resetting scroll position
- replace the mobile mission dispatch list with auto, run card, manual, and unit type actions that open focused panels
- implement the supporting dispatch logic and refreshed styles for the new mobile workflow

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e2935c916c83288c467daa2c725cba