### PR TITLE
Use responding_count for mission warning level classification

### DIFF
--- a/public/js/missions.js
+++ b/public/js/missions.js
@@ -9,7 +9,7 @@ export async function getMissions() {
 export function sortMissions(missions) {
   const level = m => {
     if (m.resolve_at) return 3;
-    return (m.assigned_count > 0) ? 2 : 1;
+    return (m.responding_count > 0) ? 2 : 1;
   };
   return missions
     .filter(m => m.status !== 'resolved')
@@ -22,7 +22,7 @@ export function sortMissions(missions) {
 }
 
 export function renderMissionRow(mission) {
-  const lvl = mission.level || (mission.resolve_at ? 3 : (mission.assigned_count > 0 ? 2 : 1));
+  const lvl = mission.level || (mission.resolve_at ? 3 : (mission.responding_count > 0 ? 2 : 1));
   const icon = `/warning${lvl}.png`;
   let time = '';
   if (mission.resolve_at) {


### PR DESCRIPTION
### Motivation
- Ensure warning level 2 reflects units that are actively enroute (responding) rather than any assigned units so sorting and icon rendering match the actual responding state.

### Description
- Updated `public/js/missions.js` to use `responding_count` for level 2 in `sortMissions()` (`return (m.responding_count > 0) ? 2 : 1;`) and made the same fallback change in `renderMissionRow()` so icon/class rendering matches the sort logic, while keeping `resolve_at` => level 3; confirmed `responding_count` is provided by `controllers/missionsController.js`.

### Testing
- Ran `npm test` (observed one unrelated existing test failure in `handleTransports`), and ran a Playwright-based UI check that evaluated `window.missionUtils.renderMissionRow(...)` for the four states and observed `warning1`, `warning1`, `warning2`, `warning3`, with a screenshot captured.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698f55dfef1c8328ad12713d60ad518f)